### PR TITLE
[MDAPI-80] [C++][IPF] Implement custom fields in InstrumentProfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(dxFeedGraalCxxApi)
 
 set(DXFCXX_VERSION "v2.0.0" CACHE STRING "The dxFeed Graal CXX API package version")
 
-set(DXFEED_GRAAL_NATIVE_SDK_VERSION "1.1.21" CACHE STRING "")
+set(DXFEED_GRAAL_NATIVE_SDK_VERSION "1.1.22" CACHE STRING "")
 set(FMTLIB_VERSION "10.2.1")
 set(BOOST_VERSION "1.84.0")
 set(UTFCPP_VERSION "3.2.3")
@@ -217,6 +217,7 @@ set(dxFeedGraalCxxApi_Isolated_Sources
         src/isolated/internal/IsolatedTimeFormat.cpp
         src/isolated/internal/IsolatedTools.cpp
         src/isolated/util/IsolatedTimePeriod.cpp
+        src/isolated/ipf/IsolatedInstrumentProfile.cpp
         src/isolated/ipf/IsolatedInstrumentProfileReader.cpp
 )
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,7 +2,7 @@
 
 ## Compile-time
 
-- [dxFeed Graal Native SDK](https://github.com/dxFeed/dxfeed-graal-native-sdk) v1.1.21
+- [dxFeed Graal Native SDK](https://github.com/dxFeed/dxfeed-graal-native-sdk) v1.1.22
 - [Boost](https://github.com/boostorg/boost) v1.84.0
   - Boost.Stacktrace 1.0
 - [utfcpp](https://github.com/nemtrif/utfcpp) v3.2.3

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,14 @@
-
+* **\[MDAPI-80]\[C++]\[IPF]** Implement custom fields in InstrumentProfile
+  * The API was migrated to Graal SDK v1.1.22
+  * Added methods:
+    * `InstrumentProfile::getField`
+    * `InstrumentProfile::setField`
+    * `InstrumentProfile::getNumericField`
+    * `InstrumentProfile::setNumericField`
+    * `InstrumentProfile::getDateField`
+    * `InstrumentProfile::setDateField`
+    * `InstrumentProfile::getNonEmptyCustomFieldNames`
+  * **\[BREAKING]**: All `toString` methods can now throw exceptions.
 * **\[MDAPI-26]\[C++]** Migrate to Graal SDK v1.1.21.
   * Added `Day::getSessions` method.
   * New order sources added: `CEDX` and `cedx`.

--- a/include/dxfeed_graal_cpp_api/api.hpp
+++ b/include/dxfeed_graal_cpp_api/api.hpp
@@ -67,6 +67,7 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251 4996)
 #include "isolated/internal/IsolatedObject.hpp"
 #include "isolated/internal/IsolatedTimeFormat.hpp"
 #include "isolated/internal/IsolatedTools.hpp"
+#include "isolated/ipf/IsolatedInstrumentProfile.hpp"
 #include "isolated/ipf/IsolatedInstrumentProfileReader.hpp"
 #include "isolated/util/IsolatedTimePeriod.hpp"
 

--- a/include/dxfeed_graal_cpp_api/api/DXEndpoint.hpp
+++ b/include/dxfeed_graal_cpp_api/api/DXEndpoint.hpp
@@ -982,7 +982,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
         std::shared_ptr<DXEndpoint> build();
     };
 
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/api/DXFeed.hpp
+++ b/include/dxfeed_graal_cpp_api/api/DXFeed.hpp
@@ -315,7 +315,7 @@ struct DXFCPP_EXPORT DXFeed : SharedEntity {
         return Promise<std::vector<std::shared_ptr<E>>>(getTimeSeriesPromiseImpl(E::TYPE, symbol, fromTime, toTime));
     }
 
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/api/DXFeedSubscription.hpp
+++ b/include/dxfeed_graal_cpp_api/api/DXFeedSubscription.hpp
@@ -133,7 +133,7 @@ class DXFCPP_EXPORT DXFeedSubscription : public RequireMakeShared<DXFeedSubscrip
     }
 
     ///
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 
     ~DXFeedSubscription() override;
 

--- a/include/dxfeed_graal_cpp_api/api/DXPublisher.hpp
+++ b/include/dxfeed_graal_cpp_api/api/DXPublisher.hpp
@@ -244,7 +244,7 @@ struct DXFCPP_EXPORT DXPublisher : SharedEntity {
      */
     std::shared_ptr<ObservableSubscription> getSubscription(const EventTypeEnum &eventType);
 
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/api/osub/IndexedEventSubscriptionSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/api/osub/IndexedEventSubscriptionSymbol.hpp
@@ -108,7 +108,7 @@ class DXFCPP_EXPORT IndexedEventSubscriptionSymbol {
      *
      * @return string representation of this indexed event subscription symbol.
      */
-    virtual std::string toString() const noexcept;
+    virtual std::string toString() const;
 
     bool operator==(const IndexedEventSubscriptionSymbol &indexedEventSubscriptionSymbol) const noexcept;
 

--- a/include/dxfeed_graal_cpp_api/api/osub/TimeSeriesSubscriptionSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/api/osub/TimeSeriesSubscriptionSymbol.hpp
@@ -102,7 +102,7 @@ class DXFCPP_EXPORT TimeSeriesSubscriptionSymbol final : public IndexedEventSubs
      *
      * @return string representation of this time-series subscription symbol.
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 
     bool operator==(const TimeSeriesSubscriptionSymbol &timeSeriesSubscriptionSymbol) const noexcept;
 

--- a/include/dxfeed_graal_cpp_api/api/osub/WildcardSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/api/osub/WildcardSymbol.hpp
@@ -90,7 +90,7 @@ struct DXFCPP_EXPORT WildcardSymbol final {
      *
      * @return string representation of this wildcard subscription symbol.
      */
-    std::string toString() const noexcept {
+    std::string toString() const {
         if constexpr (Debugger::isDebug) {
             return "WildcardSymbol{" + symbol_ + "}";
         } else {

--- a/include/dxfeed_graal_cpp_api/entity/SharedEntity.hpp
+++ b/include/dxfeed_graal_cpp_api/entity/SharedEntity.hpp
@@ -66,7 +66,7 @@ struct DXFCPP_EXPORT SharedEntity : public Entity, std::enable_shared_from_this<
      *
      * @return a string representation
      */
-    virtual std::string toString() const noexcept {
+    virtual std::string toString() const {
         return "SharedEntity{}";
     }
 };

--- a/include/dxfeed_graal_cpp_api/event/EventFlag.hpp
+++ b/include/dxfeed_graal_cpp_api/event/EventFlag.hpp
@@ -415,7 +415,7 @@ class EventFlagsMask final {
     }
 
     ///
-    std::string toString() const noexcept {
+    std::string toString() const {
         bool addOrSign = false;
         std::ostringstream result{};
 

--- a/include/dxfeed_graal_cpp_api/event/EventType.hpp
+++ b/include/dxfeed_graal_cpp_api/event/EventType.hpp
@@ -73,7 +73,7 @@ struct DXFCPP_EXPORT EventType : public SharedEntity {
     virtual void *toGraal() const = 0;
 
     ///
-    std::string toString() const noexcept override {
+    std::string toString() const override {
         return "EventType{}";
     }
 

--- a/include/dxfeed_graal_cpp_api/event/IndexedEventSource.hpp
+++ b/include/dxfeed_graal_cpp_api/event/IndexedEventSource.hpp
@@ -88,7 +88,7 @@ class DXFCPP_EXPORT IndexedEventSource {
      *
      * @return The string representation of the object.
      */
-    std::string toString() const noexcept {
+    std::string toString() const {
         return name_;
     }
 

--- a/include/dxfeed_graal_cpp_api/event/candle/Candle.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/Candle.hpp
@@ -690,7 +690,7 @@ class DXFCPP_EXPORT Candle final : public EventTypeWithSymbol<CandleSymbol>,
         return *this;
     }
 
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/candle/CandleAlignment.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandleAlignment.hpp
@@ -87,7 +87,7 @@ struct DXFCPP_EXPORT CandleAlignment : public CandleSymbolAttribute {
      *
      * @return string representation of this candle alignment.
      */
-    std::string toString() const noexcept {
+    std::string toString() const {
         return string_;
     }
 

--- a/include/dxfeed_graal_cpp_api/event/candle/CandleExchange.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandleExchange.hpp
@@ -73,7 +73,7 @@ struct DXFCPP_EXPORT CandleExchange : public CandleSymbolAttribute {
      *
      * @return string representation of this exchange.
      */
-    std::string toString() const noexcept {
+    std::string toString() const {
         return exchangeCode_ == '\0' ? "COMPOSITE" : std::string(1, exchangeCode_);
     }
 

--- a/include/dxfeed_graal_cpp_api/event/candle/CandlePriceLevel.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandlePriceLevel.hpp
@@ -77,7 +77,7 @@ struct DXFCPP_EXPORT CandlePriceLevel : public CandleSymbolAttribute {
      *
      * @return string representation of this price level.
      */
-    std::string toString() const noexcept {
+    std::string toString() const {
         if (math::equals(value_, static_cast<std::int64_t>(value_))) {
             return std::to_string(static_cast<std::int64_t>(value_));
         }

--- a/include/dxfeed_graal_cpp_api/event/market/AnalyticOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/AnalyticOrder.hpp
@@ -540,7 +540,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/OptionSale.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OptionSale.hpp
@@ -851,7 +851,7 @@ class DXFCPP_EXPORT OptionSale final : public MarketEvent, public IndexedEvent {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/Order.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Order.hpp
@@ -534,7 +534,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/OrderBase.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OrderBase.hpp
@@ -669,7 +669,7 @@ class DXFCPP_EXPORT OrderBase : public MarketEvent, public IndexedEvent {
      *
      * @return string representation of this order event's fields.
      */
-    std::string baseFieldsToString() const noexcept;
+    std::string baseFieldsToString() const;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/OtcMarketsOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OtcMarketsOrder.hpp
@@ -721,7 +721,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/Profile.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Profile.hpp
@@ -478,7 +478,7 @@ class DXFCPP_EXPORT Profile final : public MarketEvent, public LastingEvent {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/Quote.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Quote.hpp
@@ -547,7 +547,7 @@ class DXFCPP_EXPORT Quote final : public MarketEvent, public LastingEvent {
      *
      * @return A string representation.
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/SpreadOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/SpreadOrder.hpp
@@ -524,7 +524,7 @@ class DXFCPP_EXPORT SpreadOrder : public OrderBase {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/Summary.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Summary.hpp
@@ -318,7 +318,7 @@ class DXFCPP_EXPORT Summary final : public MarketEvent, public LastingEvent {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/TimeAndSale.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/TimeAndSale.hpp
@@ -653,7 +653,7 @@ class DXFCPP_EXPORT TimeAndSale final : public MarketEvent, public TimeSeriesEve
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/Trade.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Trade.hpp
@@ -128,7 +128,7 @@ class DXFCPP_EXPORT Trade final : public TradeBase {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/TradeBase.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/TradeBase.hpp
@@ -394,7 +394,7 @@ class DXFCPP_EXPORT TradeBase : public MarketEvent, public LastingEvent {
      *
      * @return string representation of this trade event's fields.
      */
-    std::string baseFieldsToString() const noexcept;
+    std::string baseFieldsToString() const;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/market/TradeETH.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/TradeETH.hpp
@@ -153,7 +153,7 @@ class DXFCPP_EXPORT TradeETH final : public TradeBase {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/misc/Message.hpp
+++ b/include/dxfeed_graal_cpp_api/event/misc/Message.hpp
@@ -208,7 +208,7 @@ class DXFCPP_EXPORT Message : public EventTypeWithSymbol<std::string> {
         return *this;
     }
 
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/option/Greeks.hpp
+++ b/include/dxfeed_graal_cpp_api/event/option/Greeks.hpp
@@ -361,7 +361,7 @@ class DXFCPP_EXPORT Greeks final : public MarketEvent, public TimeSeriesEvent, p
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/option/Series.hpp
+++ b/include/dxfeed_graal_cpp_api/event/option/Series.hpp
@@ -517,7 +517,7 @@ class DXFCPP_EXPORT Series final : public MarketEvent, public IndexedEvent {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/option/TheoPrice.hpp
+++ b/include/dxfeed_graal_cpp_api/event/option/TheoPrice.hpp
@@ -352,7 +352,7 @@ class DXFCPP_EXPORT TheoPrice final : public MarketEvent, public TimeSeriesEvent
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/event/option/Underlying.hpp
+++ b/include/dxfeed_graal_cpp_api/event/option/Underlying.hpp
@@ -363,7 +363,7 @@ class DXFCPP_EXPORT Underlying final : public MarketEvent, public TimeSeriesEven
      *
      * @return a string representation
      */
-    std::string toString() const noexcept override;
+    std::string toString() const override;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/exceptions/JavaException.hpp
+++ b/include/dxfeed_graal_cpp_api/exceptions/JavaException.hpp
@@ -80,6 +80,14 @@ struct DXFCPP_EXPORT JavaException : public std::runtime_error {
         return v;
     }
 
+    template <typename T> static constexpr T throwIfMinusInf(T v) {
+        if (v == -std::numeric_limits<T>::infinity()) {
+            throwIfJavaThreadExceptionExists();
+        }
+
+        return v;
+    }
+
     /**
      * @return dxFeed Graal CXX API stack trace + Java (GraalVM) exception's stack trace.
      */

--- a/include/dxfeed_graal_cpp_api/internal/Isolate.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/Isolate.hpp
@@ -262,7 +262,7 @@ class Isolate final {
         }
     }
 
-    std::string toString() const noexcept {
+    std::string toString() const {
         return std::string("Isolate{") + dxfcpp::toString(handle_) + ", main = " + mainIsolateThread_.toString() +
                ", current = " + currentIsolateThread_.toString() + "}";
     }

--- a/include/dxfeed_graal_cpp_api/internal/JavaObjectHandle.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/JavaObjectHandle.hpp
@@ -36,7 +36,7 @@ template <typename T> struct JavaObjectHandle {
     JavaObjectHandle &operator=(JavaObjectHandle &&) noexcept = default;
     virtual ~JavaObjectHandle() noexcept = default;
 
-    [[nodiscard]] std::string toString() const noexcept {
+    [[nodiscard]] std::string toString() const {
         if (impl_)
             return dxfcpp::toString(impl_.get());
         else
@@ -77,7 +77,7 @@ template <typename T> struct JavaObjectHandleList {
     JavaObjectHandleList &operator=(JavaObjectHandleList &&) noexcept = default;
     virtual ~JavaObjectHandleList() noexcept = default;
 
-    [[nodiscard]] std::string toString() const noexcept {
+    [[nodiscard]] std::string toString() const {
         if (impl_)
             return dxfcpp::toString(impl_.get());
         else

--- a/include/dxfeed_graal_cpp_api/ipf/InstrumentProfile.hpp
+++ b/include/dxfeed_graal_cpp_api/ipf/InstrumentProfile.hpp
@@ -23,6 +23,7 @@ class IterableInstrumentProfile;
 struct NonOwningInstrumentProfileIterator;
 class InstrumentProfileReader;
 class InstrumentProfileCollector;
+struct Schedule;
 
 /**
  * Represents basic profile information about market instrument.
@@ -34,6 +35,7 @@ struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<Instrume
     friend NonOwningInstrumentProfileIterator;
     friend InstrumentProfileReader;
     friend InstrumentProfileCollector;
+    friend Schedule;
 
     /// The alias to a type of shared pointer to the InstrumentProfile object
     using Ptr = std::shared_ptr<InstrumentProfile>;
@@ -697,7 +699,7 @@ struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<Instrume
      * @param name name of field.
      * @return field value.
      */
-    double getNumericField(const StringLikeWrapper &name);
+    double getNumericField(const StringLikeWrapper &name) const;
 
     /**
      * Changes numeric field value with a specified name.
@@ -705,7 +707,7 @@ struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<Instrume
      * @param name name of field.
      * @param value field value.
      */
-    void setNumericField(const StringLikeWrapper &name, double value);
+    void setNumericField(const StringLikeWrapper &name, double value) const;
 
     /**
      * Returns day id value for a date field with a specified name.
@@ -713,7 +715,7 @@ struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<Instrume
      * @param name name of field.
      * @return day id value.
      */
-    std::int32_t getDateField(const StringLikeWrapper &name);
+    std::int32_t getDateField(const StringLikeWrapper &name) const;
 
     /**
      * Changes day id value for a date field with a specified name.
@@ -721,7 +723,7 @@ struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<Instrume
      * @param name name of field.
      * @param value day id value.
      */
-    void setDateField(const StringLikeWrapper &name, std::int32_t value);
+    void setDateField(const StringLikeWrapper &name, std::int32_t value) const;
 
     /**
      * Returns names of non-empty custom fields
@@ -730,6 +732,28 @@ struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<Instrume
      */
     std::vector<std::string> getNonEmptyCustomFieldNames() const;
 
+    std::string toString() const override;
+
+    friend std::ostream &operator<<(std::ostream &os, const InstrumentProfile &ip) {
+        return os << ip.toString();
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const InstrumentProfile::Ptr &ip) {
+        return os << ip->toString();
+    }
+
+    std::size_t hashCode() const;
+
+    bool operator==(const InstrumentProfile &other) const;
+
+    friend bool operator==(const InstrumentProfile::Ptr &ip1, const InstrumentProfile::Ptr &ip2) {
+        if (ip1.get() == ip2.get()) {
+            return true;
+        }
+
+        return *ip1.get() == *ip2.get();
+    }
+
     ~InstrumentProfile() noexcept override;
 
     InstrumentProfile(const InstrumentProfile &) = delete;
@@ -737,10 +761,10 @@ struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<Instrume
     InstrumentProfile &operator=(const InstrumentProfile &) = delete;
     InstrumentProfile &operator=(const InstrumentProfile &&) noexcept = delete;
 
+    explicit InstrumentProfile(LockExternalConstructionTag, JavaObjectHandle<InstrumentProfile> &&handle);
+
   private:
     JavaObjectHandle<InstrumentProfile> handle_;
-
-    explicit InstrumentProfile(LockExternalConstructionTag, JavaObjectHandle<InstrumentProfile> &&handle);
 
     static Ptr create(JavaObjectHandle<InstrumentProfile> &&handle);
 
@@ -758,5 +782,17 @@ struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<Instrume
 };
 
 DXFCPP_END_NAMESPACE
+
+template <> struct std::hash<dxfcpp::InstrumentProfile> {
+    std::size_t operator()(const dxfcpp::InstrumentProfile &t) const noexcept {
+        return t.hashCode();
+    }
+};
+
+template <> struct std::hash<dxfcpp::InstrumentProfile::Ptr> {
+    std::size_t operator()(const dxfcpp::InstrumentProfile::Ptr &t) const noexcept {
+        return t->hashCode();
+    }
+};
 
 DXFCXX_DISABLE_MSC_WARNINGS_POP()

--- a/include/dxfeed_graal_cpp_api/ipf/InstrumentProfile.hpp
+++ b/include/dxfeed_graal_cpp_api/ipf/InstrumentProfile.hpp
@@ -19,79 +19,22 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
 
 DXFCPP_BEGIN_NAMESPACE
 
+class IterableInstrumentProfile;
+struct NonOwningInstrumentProfileIterator;
+class InstrumentProfileReader;
+class InstrumentProfileCollector;
+
 /**
  * Represents basic profile information about market instrument.
  * Please see <a href="http://www.dxfeed.com/downloads/documentation/dxFeed_Instrument_Profile_Format.pdf">Instrument
  * Profile Format documentation</a> for complete description.
  */
-class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
-    struct Data {
-        std::string type{};
-        std::string symbol{};
-        std::string description{};
-        std::string localSymbol{};
-        std::string localDescription{};
-        std::string country{};
-        std::string opol{};
-        std::string exchangeData{};
-        std::string exchanges{};
-        std::string currency{};
-        std::string baseCurrency{};
-        std::string cfi{};
-        std::string isin{};
-        std::string sedol{};
-        std::string cusip{};
-        std::int32_t icb{};
-        std::int32_t sic{};
-        double multiplier = math::NaN;
-        std::string product{};
-        std::string underlying{};
-        double spc = math::NaN;
-        std::string additionalUnderlyings{};
-        std::string mmy{};
-        int32_t expiration{};
-        int32_t lastTrade{};
-        double strike = math::NaN;
-        std::string optionType{};
-        std::string expirationStyle{};
-        std::string settlementStyle{};
-        std::string priceIncrements{};
-        std::string tradingHours{};
-        std::vector<std::string> rawCustomFields{};
-        std::unordered_map<std::string, std::string> customFields{};
-    };
+struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<InstrumentProfile> {
+    friend IterableInstrumentProfile;
+    friend NonOwningInstrumentProfileIterator;
+    friend InstrumentProfileReader;
+    friend InstrumentProfileCollector;
 
-    Data data_{};
-
-    void fillData(void *graalNative) noexcept;
-    void fillGraalData(void *graalNative) const;
-    static void freeGraalData(void *graalNative) noexcept;
-
-    /**
-     * Returns custom field value with a specified name.
-     *
-     * @param name The name of custom field.
-     * @return The reference to custom field value with a specified name or std::nullopt
-     */
-    std::optional<std::reference_wrapper<const std::string>> getCustomField(const std::string &name) const noexcept {
-        if (!data_.customFields.contains(name)) {
-            return std::nullopt;
-        }
-
-        return std::cref(data_.customFields.at(name));
-    }
-
-    /**
-     * Changes custom field value with a specified name.
-     *
-     * @param name The name of custom field.
-     * @param value The custom field value.
-     */
-    void setCustomField(const std::string &name, const std::string &value) {
-        data_.customFields[name] = value;
-    }
-
-  public:
     /// The alias to a type of shared pointer to the InstrumentProfile object
     using Ptr = std::shared_ptr<InstrumentProfile>;
 
@@ -99,44 +42,15 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
     using Unique = std::unique_ptr<InstrumentProfile>;
 
     /**
-     * Creates an object of the current type and fills it with data from the the dxFeed Graal SDK structure.
-     *
-     * @param graalNative The pointer to the dxFeed Graal SDK structure.
-     * @return The object of current type.
-     * @throws std::invalid_argument
+     * Creates an instrument profile with default values.
      */
-    static Ptr fromGraal(void *graalNative);
+    static Ptr create();
 
     /**
-     * Creates a vector of objects of the current type and fills it with data from the the dxFeed Graal SDK list of
-     * structures.
-     *
-     * @param graalList The pointer to the dxFeed Graal SDK list of structures.
-     * @return The vector of objects of current type
-     * @throws std::invalid_argument
+     * Creates an instrument profile as a copy of the specified instrument profile.
+     * @param ip an instrument profile to copy.
      */
-    static std::vector<Ptr> fromGraalList(void *graalList);
-
-    /**
-     * Allocates memory for the dxFeed Graal SDK structure.
-     * Fills the dxFeed Graal SDK structure's fields by the data of the current entity.
-     * Returns the pointer to the filled structure.
-     *
-     * @return The pointer to the filled dxFeed Graal SDK structure
-     */
-    void *toGraal() const;
-
-    /**
-     * Releases the memory occupied by the dxFeed Graal SDK structure.
-     *
-     * @param graalNative The pointer to the dxFeed Graal SDK structure.
-     */
-    static void freeGraal(void *graalNative);
-
-    /**
-     * Creates new instrument profile with default values.
-     */
-    InstrumentProfile() noexcept = default;
+    static Ptr create(Ptr ip);
 
     /**
      * Returns type of instrument.
@@ -146,9 +60,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return type of instrument.
      */
-    const std::string &getType() const & noexcept {
-        return data_.type;
-    }
+    std::string getType() const;
 
     /**
      * Changes type of instrument.
@@ -158,21 +70,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param type The type of instrument.
      */
-    void setType(const std::string &type) noexcept {
-        data_.type = type;
-    }
-
-    /**
-     * Changes type of instrument and returns the current instrument profile.
-     *
-     * @param type The type of instrument.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withType(const std::string &type) noexcept {
-        InstrumentProfile::setType(type);
-
-        return *this;
-    }
+    void setType(const StringLikeWrapper &type) const;
 
     /**
      * Returns identifier of instrument, preferable an international one in Latin alphabet.
@@ -181,9 +79,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The identifier of instrument.
      */
-    const std::string &getSymbol() const & noexcept {
-        return data_.symbol;
-    }
+    std::string getSymbol() const;
 
     /**
      * Changes identifier of instrument, preferable an international one in Latin alphabet.
@@ -192,23 +88,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param symbol The identifier of instrument.
      */
-    void setSymbol(const std::string &symbol) noexcept {
-        data_.symbol = symbol;
-    }
-
-    /**
-     * Changes identifier of instrument, preferable an international one in Latin alphabet.
-     * It is a mandatory field. It may not be empty.
-     * Example: "GOOG", "/YGM9", ".ZYEAD".
-     *
-     * @param symbol The identifier of instrument.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withSymbol(const std::string &symbol) noexcept {
-        InstrumentProfile::setSymbol(symbol);
-
-        return *this;
-    }
+    void setSymbol(const StringLikeWrapper &symbol) const;
 
     /**
      * Returns the description of instrument, preferable an international one in Latin alphabet.
@@ -216,9 +96,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The description of instrument.
      */
-    const std::string &getDescription() const & noexcept {
-        return data_.description;
-    }
+    std::string getDescription() const;
 
     /**
      * Changes description of instrument, preferable an international one in Latin alphabet.
@@ -226,22 +104,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param description The description of instrument.
      */
-    void setDescription(const std::string &description) noexcept {
-        data_.description = description;
-    }
-
-    /**
-     * Changes description of instrument, preferable an international one in Latin alphabet.
-     * Example: "Google Inc.", "Mini Gold Futures,Jun-2009,ETH".
-     *
-     * @param description The description of instrument.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withDescription(const std::string &description) noexcept {
-        InstrumentProfile::setDescription(description);
-
-        return *this;
-    }
+    void setDescription(const StringLikeWrapper &description) const;
 
     /**
      * Returns identifier of instrument in national language.
@@ -249,9 +112,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The identifier of instrument in national language.
      */
-    const std::string &getLocalSymbol() const & noexcept {
-        return data_.localSymbol;
-    }
+    std::string getLocalSymbol() const;
 
     /**
      * Changes identifier of instrument in national language.
@@ -259,22 +120,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param localSymbol The identifier of instrument in national language.
      */
-    void setLocalSymbol(const std::string &localSymbol) noexcept {
-        data_.localSymbol = localSymbol;
-    }
-
-    /**
-     * Changes identifier of instrument in national language.
-     * It shall be empty if same as @ref InstrumentProfile::getSymbol() "symbol".
-     *
-     * @param localSymbol The identifier of instrument in national language.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withLocalSymbol(const std::string &localSymbol) noexcept {
-        InstrumentProfile::setLocalSymbol(localSymbol);
-
-        return *this;
-    }
+    void setLocalSymbol(const StringLikeWrapper &localSymbol) const;
 
     /**
      * Returns description of instrument in national language.
@@ -282,9 +128,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The description of instrument in national language.
      */
-    const std::string &getLocalDescription() const & noexcept {
-        return data_.localDescription;
-    }
+    std::string getLocalDescription() const;
 
     /**
      * Changes description of instrument in national language.
@@ -292,22 +136,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param localDescription The description of instrument in national language.
      */
-    void setLocalDescription(const std::string &localDescription) noexcept {
-        data_.localDescription = localDescription;
-    }
-
-    /**
-     * Changes description of instrument in national language.
-     * It shall be empty if same as @ref InstrumentProfile::getDescription() "description".
-     *
-     * @param localDescription The description of instrument in national language.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withLocalDescription(const std::string &localDescription) noexcept {
-        InstrumentProfile::setLocalDescription(localDescription);
-
-        return *this;
-    }
+    void setLocalDescription(const StringLikeWrapper &localDescription) const;
 
     /**
      * Returns country of origin (incorporation) of corresponding company or parent entity.
@@ -317,9 +146,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The country of origin (incorporation) of corresponding company or parent entity.
      */
-    const std::string &getCountry() const & noexcept {
-        return data_.country;
-    }
+    std::string getCountry() const;
 
     /**
      * Changes country of origin (incorporation) of corresponding company or parent entity.
@@ -329,24 +156,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param country The country of origin (incorporation) of corresponding company or parent entity.
      */
-    void setCountry(const std::string &country) noexcept {
-        data_.country = country;
-    }
-
-    /**
-     * Changes country of origin (incorporation) of corresponding company or parent entity.
-     * It shall use two-letter country code from ISO 3166-1 standard.
-     * See <a href="http://en.wikipedia.org/wiki/ISO_3166-1">ISO 3166-1 on Wikipedia</a>.
-     * Example: "US", "RU".
-     *
-     * @param country The country of origin (incorporation) of corresponding company or parent entity.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withCountry(const std::string &country) noexcept {
-        InstrumentProfile::setCountry(country);
-
-        return *this;
-    }
+    void setCountry(const StringLikeWrapper &country) const;
 
     /**
      * Returns official Place Of Listing, the organization that have listed this instrument.
@@ -358,9 +168,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The official Place Of Listing, the organization that have listed this instrument.
      */
-    const std::string &getOPOL() const & noexcept {
-        return data_.opol;
-    }
+    std::string getOPOL() const;
 
     /**
      * Changes official Place Of Listing, the organization that have listed this instrument.
@@ -372,26 +180,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param opol The official Place Of Listing, the organization that have listed this instrument.
      */
-    void setOPOL(const std::string &opol) noexcept {
-        data_.opol = opol;
-    }
-
-    /**
-     * Changes official Place Of Listing, the organization that have listed this instrument.
-     * Instruments with multiple listings shall use separate profiles for each listing.
-     * It shall use Market Identifier Code (MIC) from ISO 10383 standard.
-     * See <a href="http://en.wikipedia.org/wiki/ISO_10383">ISO 10383 on Wikipedia</a>
-     * or <a href="http://www.iso15022.org/MIC/homepageMIC.htm">MIC homepage</a>.
-     * Example: "XNAS", "RTSX"
-     *
-     * @param opol The official Place Of Listing, the organization that have listed this instrument.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withOPOL(const std::string &opol) noexcept {
-        InstrumentProfile::setOPOL(opol);
-
-        return *this;
-    }
+    void setOPOL(const StringLikeWrapper &opol) const;
 
     /**
      * Returns exchange-specific data required to properly identify instrument when communicating with exchange.
@@ -399,9 +188,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The exchange-specific data required to properly identify instrument when communicating with exchange.
      */
-    const std::string &getExchangeData() const & noexcept {
-        return data_.exchangeData;
-    }
+    std::string getExchangeData() const;
 
     /**
      * Changes exchange-specific data required to properly identify instrument when communicating with exchange.
@@ -410,23 +197,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      * @param exchangeData The exchange-specific data required to properly identify instrument when communicating with
      * exchange.
      */
-    void setExchangeData(const std::string &exchangeData) noexcept {
-        data_.exchangeData = exchangeData;
-    }
-
-    /**
-     * Changes exchange-specific data required to properly identify instrument when communicating with exchange.
-     * It uses exchange-specific format.
-     *
-     * @param exchangeData The exchange-specific data required to properly identify instrument when communicating with
-     * exchange.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withExchangeData(const std::string &exchangeData) noexcept {
-        InstrumentProfile::setExchangeData(exchangeData);
-
-        return *this;
-    }
+    void setExchangeData(const StringLikeWrapper &exchangeData) const;
 
     /**
      * Returns list of exchanges where instrument is quoted or traded.
@@ -441,9 +212,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The list of exchanges where instrument is quoted or traded.
      */
-    const std::string &getExchanges() const & noexcept {
-        return data_.exchanges;
-    }
+    std::string getExchanges() const;
 
     /**
      * Changes list of exchanges where instrument is quoted or traded.
@@ -458,29 +227,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param exchanges The list of exchanges where instrument is quoted or traded.
      */
-    void setExchanges(const std::string &exchanges) noexcept {
-        data_.exchanges = exchanges;
-    }
-
-    /**
-     * Changes list of exchanges where instrument is quoted or traded.
-     * It shall use the following format:
-     * ```
-     *     <VALUE> ::= <empty> | <LIST>
-     *     <LIST> ::= <MIC> | <MIC> <semicolon>
-     *
-     *     <LIST> the list shall be sorted by MIC.
-     * ```
-     * Example: "ARCX;CBSX ;XNAS;XNYS".
-     *
-     * @param exchanges The list of exchanges where instrument is quoted or traded.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withExchanges(const std::string &exchanges) noexcept {
-        InstrumentProfile::setExchanges(exchanges);
-
-        return *this;
-    }
+    void setExchanges(const StringLikeWrapper &exchanges) const;
 
     /**
      * Returns currency of quotation, pricing and trading.
@@ -490,9 +237,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return Currency of quotation, pricing and trading.
      */
-    const std::string &getCurrency() const & noexcept {
-        return data_.currency;
-    }
+    std::string getCurrency() const;
 
     /**
      * Changes currency of quotation, pricing and trading.
@@ -502,24 +247,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param currency Currency of quotation, pricing and trading.
      */
-    void setCurrency(const std::string &currency) noexcept {
-        data_.currency = currency;
-    }
-
-    /**
-     * Changes currency of quotation, pricing and trading.
-     * It shall use three-letter currency code from ISO 4217 standard.
-     * See <a href="http://en.wikipedia.org/wiki/ISO_4217">ISO 4217 on Wikipedia</a>.
-     * Example: "USD", "RUB".
-     *
-     * @param currency Currency of quotation, pricing and trading.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withCurrency(const std::string &currency) noexcept {
-        InstrumentProfile::setCurrency(currency);
-
-        return *this;
-    }
+    void setCurrency(const StringLikeWrapper &currency) const;
 
     /**
      * Returns base currency of currency pair (FOREX instruments).
@@ -527,9 +255,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The base currency of currency pair (FOREX instruments).
      */
-    const std::string &getBaseCurrency() const & noexcept {
-        return data_.baseCurrency;
-    }
+    std::string getBaseCurrency() const;
 
     /**
      * Changes base currency of currency pair (FOREX instruments).
@@ -537,22 +263,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param baseCurrency The base currency of currency pair (FOREX instruments).
      */
-    void setBaseCurrency(const std::string &baseCurrency) noexcept {
-        data_.baseCurrency = baseCurrency;
-    }
-
-    /**
-     * Changes base currency of currency pair (FOREX instruments).
-     * It shall use three-letter currency code similarly to @ref InstrumentProfile::getCurrency() "currency".
-     *
-     * @param baseCurrency The base currency of currency pair (FOREX instruments).
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withBaseCurrency(const std::string &baseCurrency) noexcept {
-        InstrumentProfile::setBaseCurrency(baseCurrency);
-
-        return *this;
-    }
+    void setBaseCurrency(const StringLikeWrapper &baseCurrency) const;
 
     /**
      * Returns Classification of Financial Instruments code.
@@ -565,9 +276,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return CFI code.
      */
-    const std::string &getCFI() const & noexcept {
-        return data_.cfi;
-    }
+    std::string getCFI() const;
 
     /**
      * Changes Classification of Financial Instruments code.
@@ -580,27 +289,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param cfi CFI code.
      */
-    void setCFI(const std::string &cfi) noexcept {
-        data_.cfi = cfi;
-    }
-
-    /**
-     * Changes Classification of Financial Instruments code.
-     * It is a mandatory field for OPTION instruments as it is the only way to distinguish Call/Put type,
-     * American/European exercise, Cash/Physical delivery.
-     * It shall use six-letter CFI code from ISO 10962 standard.
-     * It is allowed to use 'X' extensively and to omit trailing letters (assumed to be 'X').
-     * See <a href="http://en.wikipedia.org/wiki/ISO_10962">ISO 10962 on Wikipedia</a>.
-     * Example: "ESNTPB", "ESXXXX", "ES" , "OPASPS".
-     *
-     * @param cfi CFI code.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withCFI(const std::string &cfi) noexcept {
-        InstrumentProfile::setCFI(cfi);
-
-        return *this;
-    }
+    void setCFI(const StringLikeWrapper &cfi) const;
 
     /**
      * Returns International Securities Identifying Number.
@@ -611,9 +300,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return International Securities Identifying Number.
      */
-    const std::string &getISIN() const & noexcept {
-        return data_.isin;
-    }
+    std::string getISIN() const;
 
     /**
      * Changes International Securities Identifying Number.
@@ -624,25 +311,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param isin International Securities Identifying Number.
      */
-    void setISIN(const std::string &isin) noexcept {
-        data_.isin = isin;
-    }
-
-    /**
-     * Changes International Securities Identifying Number.
-     * It shall use twelve-letter code from ISO 6166 standard.
-     * See <a href="http://en.wikipedia.org/wiki/ISO_6166">ISO 6166 on Wikipedia</a>
-     * or <a href="http://en.wikipedia.org/wiki/International_Securities_Identifying_Number">ISIN on Wikipedia</a>.
-     * Example: "DE0007100000", "US38259P5089".
-     *
-     * @param isin International Securities Identifying Number.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withISIN(const std::string &isin) noexcept {
-        InstrumentProfile::setISIN(isin);
-
-        return *this;
-    }
+    void setISIN(const StringLikeWrapper &isin) const;
 
     /**
      * Returns Stock Exchange Daily Official List.
@@ -653,9 +322,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return Stock Exchange Daily Official List.
      */
-    const std::string &getSEDOL() const & noexcept {
-        return data_.sedol;
-    }
+    std::string getSEDOL() const;
 
     /**
      * Changes Stock Exchange Daily Official List.
@@ -666,25 +333,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param sedol Stock Exchange Daily Official List.
      */
-    void setSEDOL(const std::string &sedol) noexcept {
-        data_.sedol = sedol;
-    }
-
-    /**
-     * Changes Stock Exchange Daily Official List.
-     * It shall use seven-letter code assigned by London Stock Exchange.
-     * See <a href="http://en.wikipedia.org/wiki/SEDOL">SEDOL on Wikipedia</a> or
-     * <a href="http://www.londonstockexchange.com/en-gb/products/informationproducts/sedol/">SEDOL on LSE</a>.
-     * Example: "2310967", "5766857".
-     *
-     * @param sedol Stock Exchange Daily Official List.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withSEDOL(const std::string &sedol) noexcept {
-        InstrumentProfile::setSEDOL(sedol);
-
-        return *this;
-    }
+    void setSEDOL(const StringLikeWrapper &sedol) const;
 
     /**
      * Returns Committee on Uniform Security Identification Procedures code.
@@ -694,9 +343,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return CUSIP code.
      */
-    const std::string &getCUSIP() const & noexcept {
-        return data_.cusip;
-    }
+    std::string getCUSIP() const;
 
     /**
      * Changes Committee on Uniform Security Identification Procedures code.
@@ -706,24 +353,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param cusip CUSIP code.
      */
-    void setCUSIP(const std::string &cusip) noexcept {
-        data_.cusip = cusip;
-    }
-
-    /**
-     * Changes Committee on Uniform Security Identification Procedures code.
-     * It shall use nine-letter code assigned by CUSIP Services Bureau.
-     * See <a href="http://en.wikipedia.org/wiki/CUSIP">CUSIP on Wikipedia</a>.
-     * Example: "38259P508".
-     *
-     * @param cusip CUSIP code
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withCUSIP(const std::string &cusip) noexcept {
-        InstrumentProfile::setCUSIP(cusip);
-
-        return *this;
-    }
+    void setCUSIP(const StringLikeWrapper &cusip) const;
 
     /**
      * Returns Industry Classification Benchmark.
@@ -734,9 +364,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return Industry Classification Benchmark.
      */
-    std::int32_t getICB() const noexcept {
-        return data_.icb;
-    }
+    std::int32_t getICB() const;
 
     /**
      * Changes Industry Classification Benchmark.
@@ -747,25 +375,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param icb Industry Classification Benchmark.
      */
-    void setICB(std::int32_t icb) noexcept {
-        data_.icb = icb;
-    }
-
-    /**
-     * Changes Industry Classification Benchmark.
-     * It shall use four-digit number from ICB catalog.
-     * See <a href="http://en.wikipedia.org/wiki/Industry_Classification_Benchmark">ICB on Wikipedia</a>
-     * or <a href="http://www.icbenchmark.com/">ICB homepage</a>.
-     * Example: "9535".
-     *
-     * @param icb Industry Classification Benchmark.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withICB(std::int32_t icb) noexcept {
-        InstrumentProfile::setICB(icb);
-
-        return *this;
-    }
+    void setICB(std::int32_t icb) const;
 
     /**
      * Returns Standard Industrial Classification.
@@ -776,9 +386,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return Standard Industrial Classification.
      */
-    std::int32_t getSIC() const noexcept {
-        return data_.sic;
-    }
+    std::int32_t getSIC() const;
 
     /**
      * Changes Standard Industrial Classification.
@@ -789,25 +397,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param sic Standard Industrial Classification.
      */
-    void setSIC(std::int32_t sic) noexcept {
-        data_.sic = sic;
-    }
-
-    /**
-     * Changes Standard Industrial Classification.
-     * It shall use four-digit number from SIC catalog.
-     * See <a href="http://en.wikipedia.org/wiki/Standard_Industrial_Classification">SIC on Wikipedia</a>
-     * or <a href="https://www.osha.gov/pls/imis/sic_manual.html">SIC structure</a>.
-     * Example: "7371".
-     *
-     * @param sic Standard Industrial Classification.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withSIC(std::int32_t sic) noexcept {
-        InstrumentProfile::setSIC(sic);
-
-        return *this;
-    }
+    void setSIC(std::int32_t sic) const;
 
     /**
      * Returns market value multiplier.
@@ -815,9 +405,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The market value multiplier.
      */
-    double getMultiplier() const noexcept {
-        return data_.multiplier;
-    }
+    double getMultiplier() const;
 
     /**
      * Changes market value multiplier.
@@ -825,22 +413,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param multiplier The market value multiplier.
      */
-    void setMultiplier(double multiplier) noexcept {
-        data_.multiplier = multiplier;
-    }
-
-    /**
-     * Changes market value multiplier.
-     * Example: 100, 33.2.
-     *
-     * @param multiplier The market value multiplier.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withMultiplier(double multiplier) noexcept {
-        InstrumentProfile::setMultiplier(multiplier);
-
-        return *this;
-    }
+    void setMultiplier(double multiplier) const;
 
     /**
      * Returns product for futures and options on futures (underlying asset name).
@@ -848,9 +421,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The product for futures and options on futures (underlying asset name).
      */
-    const std::string &getProduct() const & noexcept {
-        return data_.product;
-    }
+    std::string getProduct() const;
 
     /**
      * Changes product for futures and options on futures (underlying asset name).
@@ -858,22 +429,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param product The product for futures and options on futures (underlying asset name).
      */
-    void setProduct(const std::string &product) noexcept {
-        data_.product = product;
-    }
-
-    /**
-     * Changes product for futures and options on futures (underlying asset name).
-     * Example: "/YG".
-     *
-     * @param product The product for futures and options on futures (underlying asset name).
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withProduct(const std::string &product) noexcept {
-        InstrumentProfile::setProduct(product);
-
-        return *this;
-    }
+    void setProduct(const StringLikeWrapper &product) const;
 
     /**
      * Returns primary underlying symbol for options.
@@ -881,9 +437,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The primary underlying symbol for options.
      */
-    const std::string &getUnderlying() const & noexcept {
-        return data_.underlying;
-    }
+    std::string getUnderlying() const;
 
     /**
      * Changes primary underlying symbol for options.
@@ -891,22 +445,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param underlying The primary underlying symbol for options.
      */
-    void setUnderlying(const std::string &underlying) noexcept {
-        data_.underlying = underlying;
-    }
-
-    /**
-     * Changes primary underlying symbol for options.
-     * Example: "C", "/YGM9"
-     *
-     * @param underlying The primary underlying symbol for options.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withUnderlying(const std::string &underlying) noexcept {
-        InstrumentProfile::setUnderlying(underlying);
-
-        return *this;
-    }
+    void setUnderlying(const StringLikeWrapper &underlying) const;
 
     /**
      * Returns shares per contract for options.
@@ -914,9 +453,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return shares per contract for options.
      */
-    double getSPC() const noexcept {
-        return data_.spc;
-    }
+    double getSPC() const;
 
     /**
      * Changes shares per contract for options.
@@ -924,22 +461,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param spc The shares per contract for options.
      */
-    void setSPC(double spc) noexcept {
-        data_.spc = spc;
-    }
-
-    /**
-     * Changes shares per contract for options.
-     * Example: 1, 100.
-     *
-     * @param spc The shares per contract for options.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withSPC(double spc) noexcept {
-        InstrumentProfile::setSPC(spc);
-
-        return *this;
-    }
+    void setSPC(double spc) const;
 
     /**
      * Returns additional underlyings for options, including additional cash.
@@ -954,9 +476,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The additional underlyings for options, including additional cash.
      */
-    const std::string &getAdditionalUnderlyings() const & noexcept {
-        return data_.additionalUnderlyings;
-    }
+    std::string getAdditionalUnderlyings() const;
 
     /**
      * Changes additional underlyings for options, including additional cash.
@@ -971,29 +491,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param additionalUnderlyings The additional underlyings for options, including additional cash.
      */
-    void setAdditionalUnderlyings(const std::string &additionalUnderlyings) noexcept {
-        data_.additionalUnderlyings = additionalUnderlyings;
-    }
-
-    /**
-     * Changes additional underlyings for options, including additional cash.
-     * It shall use following format:
-     * ```
-     *     <VALUE> ::= <empty> | <LIST>
-     *     <LIST> ::= <AU> | <AU> <semicolon> <space> <LIST>
-     *     <AU> ::= <UNDERLYING> <space> <SPC>
-     * the list shall be sorted by <UNDERLYING>.
-     * ```
-     * Example: "SE 50", "FIS 53; US$ 45.46".
-     *
-     * @param additionalUnderlyings The additional underlyings for options, including additional cash.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withAdditionalUnderlyings(const std::string &additionalUnderlyings) noexcept {
-        InstrumentProfile::setAdditionalUnderlyings(additionalUnderlyings);
-
-        return *this;
-    }
+    void setAdditionalUnderlyings(const StringLikeWrapper &additionalUnderlyings) const;
 
     /**
      * Returns maturity month-year as provided for corresponding FIX tag (200).
@@ -1006,9 +504,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The maturity month-year as provided for corresponding FIX tag (200).
      */
-    const std::string &getMMY() const & noexcept {
-        return data_.mmy;
-    }
+    std::string getMMY() const;
 
     /**
      * Changes maturity month-year as provided for corresponding FIX tag (200).
@@ -1021,27 +517,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param mmy The maturity month-year as provided for corresponding FIX tag (200).
      */
-    void setMMY(const std::string &mmy) noexcept {
-        data_.mmy = mmy;
-    }
-
-    /**
-     * Changes maturity month-year as provided for corresponding FIX tag (200).
-     * It can use several different formats depending on data source:
-     * <ul>
-     * <li>YYYYMM – if only year and month are specified
-     * <li>YYYYMMDD – if full date is specified
-     * <li>YYYYMMwN – if week number (within a month) is specified
-     * </ul>
-     *
-     * @param mmy The maturity month-year as provided for corresponding FIX tag (200).
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withMMY(const std::string &mmy) noexcept {
-        InstrumentProfile::setMMY(mmy);
-
-        return *this;
-    }
+    void setMMY(const StringLikeWrapper &mmy) const;
 
     /**
      * Returns day id of expiration.
@@ -1049,9 +525,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The day id of expiration.
      */
-    std::int32_t getExpiration() const noexcept {
-        return data_.expiration;
-    }
+    std::int32_t getExpiration() const;
 
     /**
      * Changes day id of expiration.
@@ -1059,22 +533,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param expiration The day id of expiration.
      */
-    void setExpiration(std::int32_t expiration) noexcept {
-        data_.expiration = expiration;
-    }
-
-    /**
-     * Changes day id of expiration.
-     * Example: @ref day_util::#getDayIdByYearMonthDay() "dxfcpp::day_util::getDayIdByYearMonthDay"(20090117).
-     *
-     * @param expiration The day id of expiration.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withExpiration(std::int32_t expiration) noexcept {
-        InstrumentProfile::setExpiration(expiration);
-
-        return *this;
-    }
+    void setExpiration(std::int32_t expiration) const;
 
     /**
      * Returns day id of last trading day.
@@ -1082,9 +541,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The day id of last trading day.
      */
-    std::int32_t getLastTrade() const noexcept {
-        return data_.lastTrade;
-    }
+    std::int32_t getLastTrade() const;
 
     /**
      * Changes day id of last trading day.
@@ -1092,22 +549,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param lastTrade The day id of last trading day.
      */
-    void setLastTrade(std::int32_t lastTrade) noexcept {
-        data_.lastTrade = lastTrade;
-    }
-
-    /**
-     * Changes day id of last trading day.
-     * Example: @ref day_util::#getDayIdByYearMonthDay() "dxfcpp::day_util::getDayIdByYearMonthDay"(20090116).
-     *
-     * @param lastTrade The day id of last trading day.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withLastTrade(std::int32_t lastTrade) noexcept {
-        InstrumentProfile::setLastTrade(lastTrade);
-
-        return *this;
-    }
+    void setLastTrade(std::int32_t lastTrade) const;
 
     /**
      * Returns strike price for options.
@@ -1115,9 +557,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The strike price for options.
      */
-    double getStrike() const noexcept {
-        return data_.strike;
-    }
+    double getStrike() const;
 
     /**
      * Changes strike price for options.
@@ -1125,22 +565,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param strike The strike price for options.
      */
-    void setStrike(double strike) noexcept {
-        data_.strike = strike;
-    }
-
-    /**
-     * Changes strike price for options.
-     * Example: 80, 22.5.
-     *
-     * @param strike The strike price for options
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withStrike(double strike) noexcept {
-        InstrumentProfile::setStrike(strike);
-
-        return *this;
-    }
+    void setStrike(double strike) const;
 
     /**
      * Returns type of option.
@@ -1157,9 +582,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The type of option.
      */
-    const std::string &getOptionType() const & noexcept {
-        return data_.optionType;
-    }
+    std::string getOptionType() const;
 
     /**
      * Changes type of option.
@@ -1176,91 +599,35 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param optionType The type of option.
      */
-    void setOptionType(const std::string &optionType) noexcept {
-        data_.optionType = optionType;
-    }
-
-    /**
-     * Changes type of option.
-     * It shall use one of following values:
-     * <ul>
-     * <li>STAN = Standard Options
-     * <li>LEAP = Long-term Equity AnticiPation Securities
-     * <li>SDO = Special Dated Options
-     * <li>BINY = Binary Options
-     * <li>FLEX = FLexible EXchange Options
-     * <li>VSO = Variable Start Options
-     * <li>RNGE = Range
-     * </ul>
-     *
-     * @param optionType The type of option.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withOptionType(const std::string &optionType) noexcept {
-        InstrumentProfile::setOptionType(optionType);
-
-        return *this;
-    }
+    void setOptionType(const StringLikeWrapper &optionType) const;
 
     /**
      * Returns expiration cycle style, such as "Weeklys", "Quarterlys".
      *
      * @return The expiration cycle style.
      */
-    const std::string &getExpirationStyle() const & noexcept {
-        return data_.expirationStyle;
-    }
+    std::string getExpirationStyle() const;
 
     /**
      * Changes the expiration cycle style, such as "Weeklys", "Quarterlys".
      *
      * @param expirationStyle The expiration cycle style.
      */
-    void setExpirationStyle(const std::string &expirationStyle) noexcept {
-        data_.expirationStyle = expirationStyle;
-    }
-
-    /**
-     * Changes the expiration cycle style, such as "Weeklys", "Quarterlys".
-     *
-     * @param expirationStyle The expiration cycle style.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withExpirationStyle(const std::string &expirationStyle) noexcept {
-        InstrumentProfile::setExpirationStyle(expirationStyle);
-
-        return *this;
-    }
+    void setExpirationStyle(const StringLikeWrapper &expirationStyle) const;
 
     /**
      * Returns settlement price determination style, such as "Open", "Close".
      *
      * @return The settlement price determination style.
      */
-    const std::string &getSettlementStyle() const & noexcept {
-        return data_.settlementStyle;
-    }
+    std::string getSettlementStyle() const;
 
     /**
      * Changes settlement price determination style, such as "Open", "Close".
      *
      * @param settlementStyle The settlement price determination style.
      */
-    void setSettlementStyle(const std::string &settlementStyle) noexcept {
-        data_.settlementStyle = settlementStyle;
-    }
-
-    /**
-     * Changes settlement price determination style, such as "Open", "Close".
-     *
-     * @param settlementStyle The settlement price determination style.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withSettlementStyle(const std::string &settlementStyle) noexcept {
-        InstrumentProfile::setSettlementStyle(settlementStyle);
-
-        return *this;
-    }
+    void setSettlementStyle(const StringLikeWrapper &settlementStyle) const;
 
     /**
      * Returns minimum allowed price increments with corresponding price ranges.
@@ -1275,9 +642,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The minimum allowed price increments with corresponding price ranges.
      */
-    const std::string &getPriceIncrements() const & noexcept {
-        return data_.priceIncrements;
-    }
+    std::string getPriceIncrements() const;
 
     /**
      * Changes minimum allowed price increments with corresponding price ranges.
@@ -1292,29 +657,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param priceIncrements The minimum allowed price increments with corresponding price ranges.
      */
-    void setPriceIncrements(const std::string &priceIncrements) noexcept {
-        data_.priceIncrements = priceIncrements;
-    }
-
-    /**
-     * Changes minimum allowed price increments with corresponding price ranges.
-     * It shall use following format:
-     * ```
-     *     <VALUE> ::= <empty> | <LIST>
-     *     <LIST> ::= <INCREMENT> | <RANGE> <semicolon> <space> <LIST>
-     *     <RANGE> ::= <INCREMENT> <space> <UPPER_LIMIT>
-     * the list shall be sorted by <UPPER_LIMIT>.
-     * ```
-     * Example: "0.25", "0.01 3; 0.05".
-     *
-     * @param priceIncrements The minimum allowed price increments with corresponding price ranges.
-     * @return The current instrument profile.
-     */
-    InstrumentProfile &withPriceIncrements(const std::string &priceIncrements) noexcept {
-        InstrumentProfile::setPriceIncrements(priceIncrements);
-
-        return *this;
-    }
+    void setPriceIncrements(const StringLikeWrapper &priceIncrements) const;
 
     /**
      * Returns trading hours specification.
@@ -1322,9 +665,7 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @return The trading hours specification.
      */
-    const std::string &getTradingHours() const & noexcept {
-        return data_.tradingHours;
-    }
+    std::string getTradingHours() const;
 
     /**
      * Changes trading hours specification.
@@ -1332,22 +673,88 @@ class DXFCPP_EXPORT InstrumentProfile final : public SharedEntity {
      *
      * @param tradingHours The trading hours specification.
      */
-    void setTradingHours(const std::string &tradingHours) noexcept {
-        data_.tradingHours = tradingHours;
-    }
+    void setTradingHours(const StringLikeWrapper &tradingHours) const;
 
     /**
-     * Changes trading hours specification.
-     * See Schedule::getInstance().
+     * Returns field value with a specified name.
      *
-     * @param tradingHours The trading hours specification.
-     * @return The current instrument profile.
+     * @param name name of field.
+     * @return field value.
      */
-    InstrumentProfile &withTradingHours(const std::string &tradingHours) noexcept {
-        InstrumentProfile::setTradingHours(tradingHours);
+    std::string getField(const StringLikeWrapper &name) const;
 
-        return *this;
-    }
+    /**
+     * Changes field value with a specified name.
+     *
+     * @param name name of field.
+     * @param value field value.
+     */
+    void setField(const StringLikeWrapper &name, const StringLikeWrapper &value) const;
+
+    /**
+     * Returns numeric field value with a specified name.
+     *
+     * @param name name of field.
+     * @return field value.
+     */
+    double getNumericField(const StringLikeWrapper &name);
+
+    /**
+     * Changes numeric field value with a specified name.
+     *
+     * @param name name of field.
+     * @param value field value.
+     */
+    void setNumericField(const StringLikeWrapper &name, double value);
+
+    /**
+     * Returns day id value for a date field with a specified name.
+     *
+     * @param name name of field.
+     * @return day id value.
+     */
+    std::int32_t getDateField(const StringLikeWrapper &name);
+
+    /**
+     * Changes day id value for a date field with a specified name.
+     *
+     * @param name name of field.
+     * @param value day id value.
+     */
+    void setDateField(const StringLikeWrapper &name, std::int32_t value);
+
+    /**
+     * Returns names of non-empty custom fields
+     *
+     * @return names of non-empty custom fields
+     */
+    std::vector<std::string> getNonEmptyCustomFieldNames() const;
+
+    ~InstrumentProfile() noexcept override;
+
+    InstrumentProfile(const InstrumentProfile &) = delete;
+    InstrumentProfile(InstrumentProfile &&) noexcept = delete;
+    InstrumentProfile &operator=(const InstrumentProfile &) = delete;
+    InstrumentProfile &operator=(const InstrumentProfile &&) noexcept = delete;
+
+  private:
+    JavaObjectHandle<InstrumentProfile> handle_;
+
+    explicit InstrumentProfile(LockExternalConstructionTag, JavaObjectHandle<InstrumentProfile> &&handle);
+
+    static Ptr create(JavaObjectHandle<InstrumentProfile> &&handle);
+
+    struct List {
+        /**
+         * Creates a vector of objects of the current type and fills it with data from the the dxFeed Graal SDK list of
+         * structures.
+         *
+         * @param list The pointer to the dxFeed Graal SDK list of structures.
+         * @return The vector of objects of current type
+         * @throws std::invalid_argument
+         */
+        static std::vector<Ptr> fromGraal(void *list);
+    };
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/ipf/live/InstrumentProfileCollector.hpp
+++ b/include/dxfeed_graal_cpp_api/ipf/live/InstrumentProfileCollector.hpp
@@ -108,16 +108,6 @@ class DXFCPP_EXPORT InstrumentProfileCollector final : public SharedEntity {
     void updateInstrumentProfile(std::shared_ptr<InstrumentProfile> ip) const;
 
     /**
-     * Convenience method to update one instrument profile in this collector. This is a shortcut for:
-     * <pre><tt>
-     *    @ref InstrumentProfileCollector::updateInstrumentProfiles() "updateInstrumentProfiles"({ip}, nullptr);
-     * </tt></pre>
-     *
-     * @param ip The instrument profile.
-     */
-    void updateInstrumentProfile(const InstrumentProfile &ip) const;
-
-    /**
      * Returns a concurrent view of the set of instrument profiles.
      * Note, that removal of instrument profile is represented by an InstrumentProfile instance with a
      * @ref InstrumentProfile::getType() "type" equal to

--- a/include/dxfeed_graal_cpp_api/isolated/Isolated.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/Isolated.hpp
@@ -62,14 +62,6 @@ struct IpfPropertyChangeListener {
     create(/* dxfg_ipf_connection_state_change_listener_func */ void *userFunc, void *userData) noexcept;
 };
 
-struct InstrumentProfile {
-    static bool release(/* dxfg_instrument_profile_t* */ void *ip) noexcept;
-};
-
-struct InstrumentProfileList {
-    static bool release(/* dxfg_instrument_profile_list * */ void *graalInstrumentProfileList) noexcept;
-};
-
 struct InstrumentProfileIterator {
     static bool hasNext(/* dxfg_iterable_ip_t * */ void *iterable) noexcept;
     static /* dxfg_instrument_profile_t* */ void *next(/* dxfg_iterable_ip_t * */ void *iterable) noexcept;

--- a/include/dxfeed_graal_cpp_api/isolated/IsolatedCommon.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/IsolatedCommon.hpp
@@ -50,6 +50,10 @@ constexpr auto throwIfMinusMin = [](auto v) {
     return JavaException::throwIfMinusMin(v);
 };
 
+constexpr auto throwIfMinusInf = [](auto v) {
+    return JavaException::throwIfMinusInf(v);
+};
+
 constexpr auto runGraalFunction(auto graalFunction, auto &&...params) {
     return runIsolatedThrow(
         [](auto threadHandle, auto &&graalFunction, auto &&...params) {
@@ -80,6 +84,10 @@ constexpr auto runGraalFunctionAndThrowIfMinusOne(auto graalFunction, auto &&...
 
 constexpr auto runGraalFunctionAndThrowIfMinusMin(auto graalFunction, auto &&...params) {
     return runGraalFunctionAndThrow(throwIfMinusMin, graalFunction, params...);
+}
+
+constexpr auto runGraalFunctionAndThrowIfMinusInf(auto graalFunction, auto &&...params) {
+    return runGraalFunctionAndThrow(throwIfMinusInf, graalFunction, params...);
 }
 
 } // namespace isolated

--- a/include/dxfeed_graal_cpp_api/isolated/internal/IsolatedString.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/internal/IsolatedString.hpp
@@ -40,6 +40,9 @@ namespace IsolatedStringList {
  * @throws GraalException if something happened with the GraalVM.
  */
 bool release(/* dxfg_string_list* */ void *stringList);
+
+std::unique_ptr<void, decltype(&release)> toUnique(void *stringList);
+
 } // namespace IsolatedStringList
 
 template <typename L> struct NativeStringListWrapper final {

--- a/include/dxfeed_graal_cpp_api/isolated/internal/IsolatedString.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/internal/IsolatedString.hpp
@@ -24,6 +24,9 @@ namespace IsolatedString {
  * @throws GraalException if something happened with the GraalVM.
  */
 bool release(const char *string);
+
+std::unique_ptr<const char, decltype(&release)> toUnique(const char *string);
+
 } // namespace IsolatedString
 
 namespace IsolatedStringList {

--- a/include/dxfeed_graal_cpp_api/isolated/ipf/IsolatedInstrumentProfile.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/ipf/IsolatedInstrumentProfile.hpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2024 Devexperts LLC.
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include "../../internal/Conf.hpp"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
+
+DXFCPP_BEGIN_NAMESPACE
+
+namespace isolated::ipf::IsolatedInstrumentProfile {
+
+/*
+dxfg_instrument_profile_t*                    dxfg_InstrumentProfile_new(graal_isolatethread_t *thread);
+dxfg_instrument_profile_t*                    dxfg_InstrumentProfile_new2(graal_isolatethread_t *thread, dxfg_instrument_profile_t* ip);
+const char*                                   dxfg_InstrumentProfile_getType(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setType(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getSymbol(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setSymbol(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getDescription(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setDescription(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getLocalSymbol(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setLocalSymbol(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getLocalDescription(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setLocalDescription(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getCountry(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setCountry(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getOPOL(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setOPOL(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getExchangeData(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setExchangeData(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getExchanges(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setExchanges(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getCurrency(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setCurrency(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getBaseCurrency(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setBaseCurrency(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getCFI(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setCFI(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getISIN(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setISIN(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getSEDOL(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setSEDOL(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getCUSIP(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setCUSIP(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+int32_t                                       dxfg_InstrumentProfile_getICB(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setICB(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, int32_t value);
+int32_t                                       dxfg_InstrumentProfile_getSIC(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setSIC(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, int32_t value);
+double                                        dxfg_InstrumentProfile_getMultiplier(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setMultiplier(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, double value);
+const char*                                   dxfg_InstrumentProfile_getProduct(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setProduct(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getUnderlying(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setUnderlying(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+double                                        dxfg_InstrumentProfile_getSPC(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setSPC(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, double value);
+const char*                                   dxfg_InstrumentProfile_getAdditionalUnderlyings(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setAdditionalUnderlyings(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getMMY(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setMMY(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+int32_t                                       dxfg_InstrumentProfile_getExpiration(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setExpiration(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, int32_t value);
+int32_t                                       dxfg_InstrumentProfile_getLastTrade(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setLastTrade(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, int32_t value);
+double                                        dxfg_InstrumentProfile_getStrike(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setStrike(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, double value);
+const char*                                   dxfg_InstrumentProfile_getOptionType(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setOptionType(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getExpirationStyle(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setExpirationStyle(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getSettlementStyle(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setSettlementStyle(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getPriceIncrements(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setPriceIncrements(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getTradingHours(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_setTradingHours(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
+const char*                                   dxfg_InstrumentProfile_getField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name);
+int32_t                                       dxfg_InstrumentProfile_setField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name, const char *value);
+double                                        dxfg_InstrumentProfile_getNumericField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name);
+int32_t                                       dxfg_InstrumentProfile_setNumericField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name, double value);
+int32_t                                       dxfg_InstrumentProfile_getDateField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name);
+int32_t                                       dxfg_InstrumentProfile_setDateField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name, int32_t value);
+dxfg_string_list*                             dxfg_InstrumentProfile_getNonEmptyCustomFieldNames(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+int32_t                                       dxfg_InstrumentProfile_release(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
+*/
+
+
+
+}
+
+DXFCPP_END_NAMESPACE
+
+DXFCXX_DISABLE_MSC_WARNINGS_POP()

--- a/include/dxfeed_graal_cpp_api/isolated/ipf/IsolatedInstrumentProfile.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/ipf/IsolatedInstrumentProfile.hpp
@@ -295,6 +295,13 @@ getNonEmptyCustomFieldNames(/* dxfg_instrument_profile_t* */ const JavaObjectHan
 
 } // namespace isolated::ipf::IsolatedInstrumentProfile
 
+namespace isolated::ipf::IsolatedInstrumentProfileList {
+void release(/* dxfg_instrument_profile_list * */ void *list);
+void releaseWrapper(/* dxfg_instrument_profile_list * */ void *list);
+
+std::unique_ptr<void, decltype(&releaseWrapper)> toUniqueWrapper(/* dxfg_instrument_profile_list * */ void *list);
+} // namespace isolated::ipf::IsolatedInstrumentProfileList
+
 DXFCPP_END_NAMESPACE
 
 DXFCXX_DISABLE_MSC_WARNINGS_POP()

--- a/include/dxfeed_graal_cpp_api/isolated/ipf/IsolatedInstrumentProfile.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/ipf/IsolatedInstrumentProfile.hpp
@@ -5,9 +5,11 @@
 
 #include "../../internal/Conf.hpp"
 
+#include "../../ipf/InstrumentProfile.hpp"
+
 #include <cstdint>
 #include <string>
-#include <string_view>
+#include <vector>
 
 DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
 
@@ -15,84 +17,283 @@ DXFCPP_BEGIN_NAMESPACE
 
 namespace isolated::ipf::IsolatedInstrumentProfile {
 
-/*
-dxfg_instrument_profile_t*                    dxfg_InstrumentProfile_new(graal_isolatethread_t *thread);
-dxfg_instrument_profile_t*                    dxfg_InstrumentProfile_new2(graal_isolatethread_t *thread, dxfg_instrument_profile_t* ip);
-const char*                                   dxfg_InstrumentProfile_getType(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setType(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getSymbol(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setSymbol(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getDescription(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setDescription(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getLocalSymbol(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setLocalSymbol(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getLocalDescription(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setLocalDescription(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getCountry(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setCountry(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getOPOL(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setOPOL(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getExchangeData(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setExchangeData(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getExchanges(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setExchanges(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getCurrency(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setCurrency(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getBaseCurrency(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setBaseCurrency(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getCFI(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setCFI(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getISIN(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setISIN(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getSEDOL(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setSEDOL(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getCUSIP(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setCUSIP(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-int32_t                                       dxfg_InstrumentProfile_getICB(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setICB(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, int32_t value);
-int32_t                                       dxfg_InstrumentProfile_getSIC(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setSIC(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, int32_t value);
-double                                        dxfg_InstrumentProfile_getMultiplier(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setMultiplier(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, double value);
-const char*                                   dxfg_InstrumentProfile_getProduct(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setProduct(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getUnderlying(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setUnderlying(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-double                                        dxfg_InstrumentProfile_getSPC(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setSPC(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, double value);
-const char*                                   dxfg_InstrumentProfile_getAdditionalUnderlyings(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setAdditionalUnderlyings(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getMMY(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setMMY(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-int32_t                                       dxfg_InstrumentProfile_getExpiration(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setExpiration(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, int32_t value);
-int32_t                                       dxfg_InstrumentProfile_getLastTrade(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setLastTrade(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, int32_t value);
-double                                        dxfg_InstrumentProfile_getStrike(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setStrike(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, double value);
-const char*                                   dxfg_InstrumentProfile_getOptionType(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setOptionType(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getExpirationStyle(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setExpirationStyle(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getSettlementStyle(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setSettlementStyle(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getPriceIncrements(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setPriceIncrements(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getTradingHours(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_setTradingHours(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *value);
-const char*                                   dxfg_InstrumentProfile_getField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name);
-int32_t                                       dxfg_InstrumentProfile_setField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name, const char *value);
-double                                        dxfg_InstrumentProfile_getNumericField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name);
-int32_t                                       dxfg_InstrumentProfile_setNumericField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name, double value);
-int32_t                                       dxfg_InstrumentProfile_getDateField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name);
-int32_t                                       dxfg_InstrumentProfile_setDateField(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip, const char *name, int32_t value);
-dxfg_string_list*                             dxfg_InstrumentProfile_getNonEmptyCustomFieldNames(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-int32_t                                       dxfg_InstrumentProfile_release(graal_isolatethread_t *thread, dxfg_instrument_profile_t *ip);
-*/
+// dxfg_InstrumentProfile_new
+/* dxfg_instrument_profile_t* */ JavaObjectHandle<InstrumentProfile> create();
 
+// dxfg_InstrumentProfile_new2
+/* dxfg_instrument_profile_t* */ JavaObjectHandle<InstrumentProfile>
+create(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
 
+// dxfg_InstrumentProfile_getType
+/* const char* */ std::string getType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
 
-}
+// dxfg_InstrumentProfile_setType
+/* std::int32_t */ void setType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getSymbol
+/* const char* */ std::string getSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setSymbol
+/* std::int32_t */ void setSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                  const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getDescription
+/* const char* */ std::string
+getDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setDescription
+/* std::int32_t */ void setDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                       const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getLocalSymbol
+/* const char* */ std::string
+getLocalSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setLocalSymbol
+/* std::int32_t */ void setLocalSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                       const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getLocalDescription
+/* const char* */ std::string
+getLocalDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setLocalDescription
+/* std::int32_t */ void
+setLocalDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                    const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getCountry
+/* const char* */ std::string
+getCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setCountry
+/* std::int32_t */ void setCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                   const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getOPOL
+/* const char* */ std::string getOPOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setOPOL
+/* std::int32_t */ void setOPOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getExchangeData
+/* const char* */ std::string
+getExchangeData(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setExchangeData
+/* std::int32_t */ void setExchangeData(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                        const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getExchanges
+/* const char* */ std::string
+getExchanges(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setExchanges
+/* std::int32_t */ void setExchanges(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                     const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getCurrency
+/* const char* */ std::string
+getCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setCurrency
+/* std::int32_t */ void setCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                    const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getBaseCurrency
+/* const char* */ std::string
+getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setBaseCurrency
+/* std::int32_t */ void setBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                        const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getCFI
+/* const char* */ std::string getCFI(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setCFI
+/* std::int32_t */ void setCFI(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getISIN
+/* const char* */ std::string getISIN(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setISIN
+/* std::int32_t */ void setISIN(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getSEDOL
+/* const char* */ std::string getSEDOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setSEDOL
+/* std::int32_t */ void setSEDOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                 const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getCUSIP
+/* const char* */ std::string getCUSIP(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setCUSIP
+/* std::int32_t */ void setCUSIP(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                 const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getICB
+std::int32_t getICB(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setICB
+/* std::int32_t */ void setICB(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               std::int32_t value);
+
+// dxfg_InstrumentProfile_getSIC
+std::int32_t getSIC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setSIC
+/* std::int32_t */ void setSIC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               std::int32_t value);
+
+// dxfg_InstrumentProfile_getMultiplier
+double getMultiplier(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setMultiplier
+/* std::int32_t */ void setMultiplier(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                      double value);
+
+// dxfg_InstrumentProfile_getProduct
+/* const char* */ std::string
+getProduct(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setProduct
+/* std::int32_t */ void setProduct(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                   const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getUnderlying
+/* const char* */ std::string
+getUnderlying(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setUnderlying
+/* std::int32_t */ void setUnderlying(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                      const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getSPC
+double getSPC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setSPC
+/* std::int32_t */ void setSPC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               double value);
+
+// dxfg_InstrumentProfile_getAdditionalUnderlyings
+/* const char* */ std::string
+getAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setAdditionalUnderlyings
+/* std::int32_t */ void
+setAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                         const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getMMY
+/* const char* */ std::string getMMY(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setMMY
+/* std::int32_t */ void setMMY(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getExpiration
+std::int32_t getExpiration(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setExpiration
+/* std::int32_t */ void setExpiration(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                      std::int32_t value);
+
+// dxfg_InstrumentProfile_getLastTrade
+std::int32_t getLastTrade(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setLastTrade
+/* std::int32_t */ void setLastTrade(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                     std::int32_t value);
+
+// dxfg_InstrumentProfile_getStrike
+double getStrike(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setStrike
+/* std::int32_t */ void setStrike(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                  double value);
+
+// dxfg_InstrumentProfile_getOptionType
+/* const char* */ std::string
+getOptionType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setOptionType
+/* std::int32_t */ void setOptionType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                      const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getExpirationStyle
+/* const char* */ std::string
+getExpirationStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setExpirationStyle
+/* std::int32_t */ void
+setExpirationStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                   const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getSettlementStyle
+/* const char* */ std::string
+getSettlementStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setSettlementStyle
+/* std::int32_t */ void
+setSettlementStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                   const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getPriceIncrements
+/* const char* */ std::string
+getPriceIncrements(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setPriceIncrements
+/* std::int32_t */ void
+setPriceIncrements(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                   const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getTradingHours
+/* const char* */ std::string
+getTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_setTradingHours
+/* std::int32_t */ void setTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                        const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getField
+/* const char* */ std::string getField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                       const StringLikeWrapper &name);
+
+// dxfg_InstrumentProfile_setField
+/* std::int32_t */ void setField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                 const StringLikeWrapper &name, const StringLikeWrapper &value);
+
+// dxfg_InstrumentProfile_getNumericField
+double getNumericField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                       const StringLikeWrapper &name);
+
+// dxfg_InstrumentProfile_setNumericField
+/* std::int32_t */ void setNumericField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                        const StringLikeWrapper &name, double value);
+
+// dxfg_InstrumentProfile_getDateField
+std::int32_t getDateField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                          const StringLikeWrapper &name);
+
+// dxfg_InstrumentProfile_setDateField
+/* std::int32_t */ void setDateField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                     const StringLikeWrapper &name, std::int32_t value);
+
+// dxfg_InstrumentProfile_getNonEmptyCustomFieldNames
+/* dxfg_string_list* */ std::vector<std::string>
+getNonEmptyCustomFieldNames(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip);
+
+// dxfg_InstrumentProfile_release
+// /* std::int32_t */ void release(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile>& ip);
+
+} // namespace isolated::ipf::IsolatedInstrumentProfile
 
 DXFCPP_END_NAMESPACE
 

--- a/include/dxfeed_graal_cpp_api/schedule/Day.hpp
+++ b/include/dxfeed_graal_cpp_api/schedule/Day.hpp
@@ -286,7 +286,7 @@ struct DXFCPP_EXPORT Day {
      *
      * @return A string representation
      */
-    std::string toString() const noexcept;
+    std::string toString() const;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/schedule/Session.hpp
+++ b/include/dxfeed_graal_cpp_api/schedule/Session.hpp
@@ -186,7 +186,7 @@ struct DXFCPP_EXPORT Session {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept;
+    std::string toString() const;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/schedule/SessionFilter.hpp
+++ b/include/dxfeed_graal_cpp_api/schedule/SessionFilter.hpp
@@ -108,7 +108,7 @@ struct DXFCPP_EXPORT SessionFilter {
         return type_ == sessionFilter.type_ && trading_ == sessionFilter.trading_;
     }
 
-    std::string toString() const noexcept {
+    std::string toString() const {
         return std::string("SessionFilter(") + ((!type_) ? "null" : type_.value().toString()) + ", " +
                ((!trading_) ? "null" : dxfcpp::toString(trading_.value())) + ")";
     }

--- a/include/dxfeed_graal_cpp_api/symbols/StringSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/symbols/StringSymbol.hpp
@@ -96,7 +96,7 @@ struct DXFCPP_EXPORT StringSymbol final {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept {
+    std::string toString() const {
         if constexpr (Debugger::isDebug) {
             return "StringSymbol{" + data_ + "}";
         } else {

--- a/include/dxfeed_graal_cpp_api/symbols/SymbolWrapper.hpp
+++ b/include/dxfeed_graal_cpp_api/symbols/SymbolWrapper.hpp
@@ -259,7 +259,7 @@ struct DXFCPP_EXPORT SymbolWrapper final {
      *
      * @return a string representation
      */
-    std::string toString() const noexcept {
+    std::string toString() const {
         return "SymbolWrapper{" +
                std::visit(
                    [](const auto &symbol) {

--- a/src/api/DXEndpoint.cpp
+++ b/src/api/DXEndpoint.cpp
@@ -359,7 +359,7 @@ std::shared_ptr<DXEndpoint::Builder> DXEndpoint::Builder::withName(const std::st
     return withProperty(NAME_PROPERTY, name);
 }
 
-std::string DXEndpoint::toString() const noexcept {
+std::string DXEndpoint::toString() const {
     return fmt::format("DXEndpoint{{{}}}", handle_.toString());
 }
 

--- a/src/api/DXFeed.cpp
+++ b/src/api/DXFeed.cpp
@@ -126,7 +126,7 @@ void *DXFeed::getTimeSeriesPromiseImpl(const EventTypeEnum &eventType, const Sym
     return isolated::api::IsolatedDXFeed::getTimeSeriesPromise(handle_, eventType, symbol, fromTime, toTime);
 }
 
-std::string DXFeed::toString() const noexcept {
+std::string DXFeed::toString() const {
     return fmt::format("DXFeed{{{}}}", handle_.toString());
 }
 

--- a/src/api/DXFeedSubscription.cpp
+++ b/src/api/DXFeedSubscription.cpp
@@ -83,7 +83,7 @@ DXFeedSubscription::DXFeedSubscription(LockExternalConstructionTag tag, const Ev
     handle_ = isolated::api::IsolatedDXFeedSubscription::create(eventType);
 }
 
-std::string DXFeedSubscription::toString() const noexcept {
+std::string DXFeedSubscription::toString() const {
     return fmt::format("DXFeedSubscription{{{}}}", handle_.toString());
 }
 

--- a/src/api/DXPublisher.cpp
+++ b/src/api/DXPublisher.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<ObservableSubscription> DXPublisher::getSubscription(const Event
     return subscription_;
 }
 
-std::string DXPublisher::toString() const noexcept {
+std::string DXPublisher::toString() const {
     return fmt::format("DXPublisher{{{}}}", handle_.toString());
 }
 

--- a/src/api/osub/IndexedEventSubscriptionSymbol.cpp
+++ b/src/api/osub/IndexedEventSubscriptionSymbol.cpp
@@ -57,7 +57,7 @@ IndexedEventSubscriptionSymbol IndexedEventSubscriptionSymbol::fromGraal(void *g
     return {SymbolWrapper::fromGraal(graalSymbol->symbol), IndexedEventSource::fromGraal(graalSymbol->source)};
 }
 
-std::string IndexedEventSubscriptionSymbol::toString() const noexcept {
+std::string IndexedEventSubscriptionSymbol::toString() const {
     if constexpr (Debugger::isDebug) {
         return "IndexedEventSubscriptionSymbol{" + eventSymbol_->toString() + ", source = " + source_.toString() + "}";
     } else {

--- a/src/api/osub/TimeSeriesSubscriptionSymbol.cpp
+++ b/src/api/osub/TimeSeriesSubscriptionSymbol.cpp
@@ -60,7 +60,7 @@ TimeSeriesSubscriptionSymbol TimeSeriesSubscriptionSymbol::fromGraal(void *graal
     return {SymbolWrapper::fromGraal(graalSymbol->symbol), graalSymbol->from_time};
 }
 
-std::string TimeSeriesSubscriptionSymbol::toString() const noexcept {
+std::string TimeSeriesSubscriptionSymbol::toString() const {
     if constexpr (Debugger::isDebug) {
         return "TimeSeriesSubscriptionSymbol{" + getEventSymbol()->toString() +
                ", fromTime = " + TimeFormat::DEFAULT_WITH_MILLIS.format(fromTime_) + "}";

--- a/src/event/candle/Candle.cpp
+++ b/src/event/candle/Candle.cpp
@@ -134,7 +134,7 @@ void Candle::freeGraal(void *graalNative) {
     delete graalCandle;
 }
 
-std::string Candle::toString() const noexcept {
+std::string Candle::toString() const {
     return fmt::format(
         "Candle{{{}, eventTime={}, eventFlags={:#x}, time={}, sequence={}, count={}, open={}, high={}, low={}, "
         "close={}, volume={}, vwap={}, bidVolume={}, askVolume={}, impVolatility={}, openInterest={}}}",

--- a/src/event/market/AnalyticOrder.cpp
+++ b/src/event/market/AnalyticOrder.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<AnalyticOrder> AnalyticOrder::fromGraal(void *graalNative) {
     return analyticOrder;
 }
 
-std::string AnalyticOrder::toString() const noexcept {
+std::string AnalyticOrder::toString() const {
     return fmt::format("AnalyticOrder{{{}, marketMaker={}, icebergPeakSize={}, icebergHiddenSize={}, "
                        "icebergExecutedSize={}, icebergType={}}}",
                        baseFieldsToString(), getMarketMaker(), dxfcpp::toString(getIcebergPeakSize()),

--- a/src/event/market/OptionSale.cpp
+++ b/src/event/market/OptionSale.cpp
@@ -111,7 +111,7 @@ void OptionSale::setExchangeCode(char exchangeCode) noexcept {
     data_.exchangeCode = utf8to16(exchangeCode);
 }
 
-std::string OptionSale::toString() const noexcept {
+std::string OptionSale::toString() const {
     return fmt::format(
         "OptionSale{{{}, eventTime={}, eventFlags={:#x}, index={:#x}, time={}, timeNanoPart={}, sequence={}, "
         "exchange={}, price={}, size={}, bid={}, ask={}, ESC='{}', TTE={}, side={}, spread={}, ETH={}, "

--- a/src/event/market/Order.cpp
+++ b/src/event/market/Order.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<Order> Order::fromGraal(void *graalNative) {
     return order;
 }
 
-std::string Order::toString() const noexcept {
+std::string Order::toString() const {
     return fmt::format("Order{{{}, marketMaker={}}}", baseFieldsToString(), getMarketMaker());
 }
 

--- a/src/event/market/OrderBase.cpp
+++ b/src/event/market/OrderBase.cpp
@@ -67,7 +67,7 @@ void OrderBase::fillGraalData(void *graalNative) const noexcept {
     graalOrderBase->trade_size = orderBaseData_.tradeSize;
 }
 
-std::string OrderBase::baseFieldsToString() const noexcept {
+std::string OrderBase::baseFieldsToString() const {
     return fmt::format(
         "{}, eventTime={}, source={}, eventFlags={:#x}, index={:#x}, time={}, sequence={}, "
         "timeNanoPart={}, action={}, actionTime={}, orderId={}, auxOrderId={}, price={}, "

--- a/src/event/market/OtcMarketsOrder.cpp
+++ b/src/event/market/OtcMarketsOrder.cpp
@@ -64,7 +64,7 @@ OtcMarketsOrder::Ptr OtcMarketsOrder::fromGraal(void *graalNative) {
     return otcMarketsOrder;
 }
 
-std::string OtcMarketsOrder::toString() const noexcept {
+std::string OtcMarketsOrder::toString() const {
     return fmt::format("OtcMarketsOrder{{{}, marketMaker={}, QAP={}, open={}, unsolicited={}, priceType={}, "
                        "saturated={}, autoEx={}, NMS={}}}",
                        baseFieldsToString(), getMarketMaker(), getQuoteAccessPayment(), isOpen(), isUnsolicited(),

--- a/src/event/market/Profile.cpp
+++ b/src/event/market/Profile.cpp
@@ -109,7 +109,7 @@ std::shared_ptr<Profile> Profile::fromGraal(void *graalNative) {
     return profile;
 }
 
-std::string Profile::toString() const noexcept {
+std::string Profile::toString() const {
     return fmt::format(
         "Profile{{{}, eventTime={}, description='{}', SSR={}, status={}, statusReason='{}', "
         "haltStartTime={}, haltEndTime={}, highLimitPrice={}, lowLimitPrice={}, high52WeekPrice={}, "

--- a/src/event/market/Quote.cpp
+++ b/src/event/market/Quote.cpp
@@ -100,7 +100,7 @@ void Quote::fillGraalData(void *graalNative) const noexcept {
     graalQuote->ask_size = data_.askSize;
 }
 
-std::string Quote::toString() const noexcept {
+std::string Quote::toString() const {
     return fmt::format(
         "Quote{{{}, eventTime={}, time={}, timeNanoPart={}, sequence={}, bidTime={}, bidExchange={}, bidPrice={}, "
         "bidSize={}, askTime={}, askExchange={}, askPrice={}, askSize={}}}",

--- a/src/event/market/SpreadOrder.cpp
+++ b/src/event/market/SpreadOrder.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<SpreadOrder> SpreadOrder::fromGraal(void *graalNative) {
     return spreadOrder;
 }
 
-std::string SpreadOrder::toString() const noexcept {
+std::string SpreadOrder::toString() const {
     return fmt::format("SpreadOrder{{{}, spreadSymbol={}}}", baseFieldsToString(), getSpreadSymbol());
 }
 

--- a/src/event/market/Summary.cpp
+++ b/src/event/market/Summary.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<Summary> Summary::fromGraal(void *graalNative) {
     return summary;
 }
 
-std::string Summary::toString() const noexcept {
+std::string Summary::toString() const {
     return fmt::format(
         "Summary{{{}, eventTime={}, day={}, dayOpen={}, dayHigh={}, dayLow='{}', "
         "dayClose={}, dayCloseType={}, prevDay={}, prevDayClose={}, prevDayCloseType={}, "

--- a/src/event/market/TimeAndSale.cpp
+++ b/src/event/market/TimeAndSale.cpp
@@ -106,7 +106,7 @@ std::shared_ptr<TimeAndSale> TimeAndSale::fromGraal(void *graalNative) {
     return timeAndSale;
 }
 
-std::string TimeAndSale::toString() const noexcept {
+std::string TimeAndSale::toString() const {
     return fmt::format("TimeAndSale{{{}, eventTime={}, eventFlags={:#x}, time={}, timeNanoPart={}, sequence={}, "
                        "exchange={}, price={}, size={}, bid={}, "
                        "ask={}, ESC='{}', TTE={}, side={}, spread={}, ETH={}, validTick={}, type={}{}{}}}",

--- a/src/event/market/Trade.cpp
+++ b/src/event/market/Trade.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<Trade> Trade::fromGraal(void *graalNative) {
     return trade;
 }
 
-std::string Trade::toString() const noexcept {
+std::string Trade::toString() const {
     return fmt::format("Trade{{{}}}", baseFieldsToString());
 }
 

--- a/src/event/market/TradeBase.cpp
+++ b/src/event/market/TradeBase.cpp
@@ -57,7 +57,7 @@ void TradeBase::fillGraalData(void *graalNative) const noexcept {
     graalTradeBase->flags = tradeBaseData_.flags;
 }
 
-std::string TradeBase::baseFieldsToString() const noexcept {
+std::string TradeBase::baseFieldsToString() const {
     return fmt::format("{}, eventTime={}, time={}, timeNanoPart={}, sequence={}, exchange={}, price={}, "
                        "change={}, size={}, day={}, dayVolume={}, dayTurnover={}, "
                        "direction={}, ETH={}",

--- a/src/event/market/TradeETH.cpp
+++ b/src/event/market/TradeETH.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<TradeETH> TradeETH::fromGraal(void *graalNative) {
     return tradeEth;
 }
 
-std::string TradeETH::toString() const noexcept {
+std::string TradeETH::toString() const {
     return fmt::format("TradeETH{{{}}}", baseFieldsToString());
 }
 

--- a/src/event/misc/Message.cpp
+++ b/src/event/misc/Message.cpp
@@ -113,7 +113,7 @@ void Message::freeGraal(void *graalNative) {
     delete graalMessage;
 }
 
-std::string Message::toString() const noexcept {
+std::string Message::toString() const {
     return fmt::format("Message{{{}, eventTime={}, attachment={}}}", getEventSymbol(),
                        TimeFormat::DEFAULT_WITH_MILLIS.format(getEventTime()), attachment_.value_or(String::NUL));
 }

--- a/src/event/option/Greeks.cpp
+++ b/src/event/option/Greeks.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<Greeks> Greeks::fromGraal(void *graalNative) {
     return greeks;
 }
 
-std::string Greeks::toString() const noexcept {
+std::string Greeks::toString() const {
     return fmt::format(
         "Greeks{{{}, eventTime={}, eventFlags={:#x}, time={}, sequence={}, price={}, volatility={}, delta={}, "
         "gamma={}, theta={}, rho={}, vega={}}}",

--- a/src/event/option/Series.cpp
+++ b/src/event/option/Series.cpp
@@ -86,7 +86,7 @@ std::shared_ptr<Series> Series::fromGraal(void *graalNative) {
     return series;
 }
 
-std::string Series::toString() const noexcept {
+std::string Series::toString() const {
     return fmt::format(
         "Series{{{}, eventTime={}, eventFlags={:#x}, index={:#x}, time={}, sequence={}, expiration={}, "
         "volatility={}, callVolume={}, putVolume={}, putCallRatio={}, forwardPrice={}, dividend={}, interest={}}}",

--- a/src/event/option/TheoPrice.cpp
+++ b/src/event/option/TheoPrice.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<TheoPrice> TheoPrice::fromGraal(void *graalNative) {
     return theoPrice;
 }
 
-std::string TheoPrice::toString() const noexcept {
+std::string TheoPrice::toString() const {
     return fmt::format(
         "TheoPrice{{{}, eventTime={}, eventFlags={:#x}, time={}, sequence={}, price={}, underlyingPrice={}, "
         "delta={}, gamma={}, dividend={}, interest={}}}",

--- a/src/event/option/Underlying.cpp
+++ b/src/event/option/Underlying.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<Underlying> Underlying::fromGraal(void *graalNative) {
     return underlying;
 }
 
-std::string Underlying::toString() const noexcept {
+std::string Underlying::toString() const {
     return fmt::format(
         "Underlying{{{}, eventTime={}, eventFlags={:#x}, time={}, sequence={}, volatility={}, frontVolatility={}, "
         "backVolatility={}, callVolume={}, putVolume={}, putCallRatio={}}}",

--- a/src/internal/Isolate.cpp
+++ b/src/internal/Isolate.cpp
@@ -436,32 +436,6 @@ IpfPropertyChangeListener::create(/* dxfg_ipf_connection_state_change_listener_f
         nullptr, dxfcpp::bit_cast<dxfg_ipf_connection_state_change_listener_func>(userFunc), userData));
 }
 
-bool InstrumentProfile::release(/* dxfg_instrument_profile_t* */ void *ip) noexcept {
-    if (!ip) {
-        // TODO: Improve error handling
-        return false;
-    }
-
-    return runIsolatedOrElse(
-        [](auto threadHandle, auto &&ip) {
-            return dxfg_InstrumentProfile_release(static_cast<graal_isolatethread_t *>(threadHandle), ip) == 0;
-        },
-        false, static_cast<dxfg_instrument_profile_t *>(ip));
-}
-
-bool InstrumentProfileList::release(/* dxfg_instrument_profile_list * */ void *graalInstrumentProfileList) noexcept {
-    if (!graalInstrumentProfileList) {
-        // TODO: Improve error handling
-        return false;
-    }
-
-    return runIsolatedOrElse(
-        [](auto threadHandle, auto &&list) {
-            return dxfg_CList_InstrumentProfile_release(static_cast<graal_isolatethread_t *>(threadHandle), list) == 0;
-        },
-        false, static_cast<dxfg_instrument_profile_list *>(graalInstrumentProfileList));
-}
-
 bool InstrumentProfileIterator::hasNext(/* dxfg_iterable_ip_t * */ void *iterable) noexcept {
     if (!iterable) {
         // TODO: Improve error handling

--- a/src/internal/JavaObjectHandle.cpp
+++ b/src/internal/JavaObjectHandle.cpp
@@ -63,6 +63,7 @@ template struct JavaObjectHandle<DXPublisher>;
 template struct JavaObjectHandle<DXFeedSubscription>;
 template struct JavaObjectHandle<DXFeedEventListener>;
 
+template struct JavaObjectHandle<InstrumentProfile>;
 template struct JavaObjectHandle<InstrumentProfileReader>;
 template struct JavaObjectHandle<InstrumentProfileCollector>;
 template struct JavaObjectHandle<InstrumentProfileConnection>;

--- a/src/internal/utils/StringUtils.cpp
+++ b/src/internal/utils/StringUtils.cpp
@@ -153,13 +153,6 @@ std::int16_t utf8to16(char in) noexcept {
 
 std::string formatTimeStamp(std::int64_t timestamp) {
     return TimeFormat::DEFAULT.format(timestamp);
-//    if (timestamp == 0) {
-//        return "0";
-//    }
-//
-//    auto tm = fmt::localtime(static_cast<std::time_t>(timestamp / 1000));
-//
-//    return fmt::format("{:%Y%m%d-%H%M%S}", tm);
 }
 
 std::string formatTimeStampWithTimeZone(std::int64_t timestamp) {
@@ -174,28 +167,10 @@ std::string formatTimeStampWithTimeZone(std::int64_t timestamp) {
 
 std::string formatTimeStampWithMillis(std::int64_t timestamp) {
     return TimeFormat::DEFAULT_WITH_MILLIS.format(timestamp);
-//
-//    if (timestamp == 0) {
-//        return "0";
-//    }
-//
-//    auto ms = timestamp % 1000;
-//    auto tm = fmt::localtime(static_cast<std::time_t>(timestamp / 1000));
-//
-//    return fmt::format("{:%Y%m%d-%H%M%S}.{:0>3}", tm, ms);
 }
 
 std::string formatTimeStampWithMillisWithTimeZone(std::int64_t timestamp) {
     return TimeFormat::DEFAULT_WITH_MILLIS_WITH_TIMEZONE.format(timestamp);
-
-//    if (timestamp == 0) {
-//        return "0";
-//    }
-//
-//    auto ms = timestamp % 1000;
-//    auto tm = fmt::localtime(static_cast<std::time_t>(timestamp / 1000));
-//
-//    return fmt::format("{:%Y%m%d-%H%M%S}.{:0>3}{:%z}", tm, ms, tm);
 }
 
 char *createCString(const std::string &s) {

--- a/src/ipf/InstrumentProfile.cpp
+++ b/src/ipf/InstrumentProfile.cpp
@@ -25,75 +25,75 @@ void InstrumentProfile::fillData(void *graalNative) noexcept {
 
     auto graalInstrumentProfile = static_cast<dxfg_instrument_profile_t *>(graalNative);
 
-    data_ = {
-        .type = dxfcpp::toString(graalInstrumentProfile->type),
-        .symbol = dxfcpp::toString(graalInstrumentProfile->symbol),
-        .description = dxfcpp::toString(graalInstrumentProfile->description),
-        .localSymbol = dxfcpp::toString(graalInstrumentProfile->local_symbol),
-        .localDescription = dxfcpp::toString(graalInstrumentProfile->local_description),
-        .country = dxfcpp::toString(graalInstrumentProfile->country),
-        .opol = dxfcpp::toString(graalInstrumentProfile->opol),
-        .exchangeData = dxfcpp::toString(graalInstrumentProfile->exchange_data),
-        .exchanges = dxfcpp::toString(graalInstrumentProfile->exchanges),
-        .currency = dxfcpp::toString(graalInstrumentProfile->currency),
-        .baseCurrency = dxfcpp::toString(graalInstrumentProfile->base_currency),
-        .cfi = dxfcpp::toString(graalInstrumentProfile->cfi),
-        .isin = dxfcpp::toString(graalInstrumentProfile->isin),
-        .sedol = dxfcpp::toString(graalInstrumentProfile->sedol),
-        .cusip = dxfcpp::toString(graalInstrumentProfile->cusip),
-        .icb = graalInstrumentProfile->icb,
-        .sic = graalInstrumentProfile->sic,
-        .multiplier = graalInstrumentProfile->multiplier,
-        .product = dxfcpp::toString(graalInstrumentProfile->product),
-        .underlying = dxfcpp::toString(graalInstrumentProfile->underlying),
-        .spc = graalInstrumentProfile->spc,
-        .additionalUnderlyings = dxfcpp::toString(graalInstrumentProfile->additional_underlyings),
-        .mmy = dxfcpp::toString(graalInstrumentProfile->mmy),
-        .expiration = graalInstrumentProfile->expiration,
-        .lastTrade = graalInstrumentProfile->last_trade,
-        .strike = graalInstrumentProfile->strike,
-        .optionType = dxfcpp::toString(graalInstrumentProfile->option_type),
-        .expirationStyle = dxfcpp::toString(graalInstrumentProfile->expiration_style),
-        .settlementStyle = dxfcpp::toString(graalInstrumentProfile->settlement_style),
-        .priceIncrements = dxfcpp::toString(graalInstrumentProfile->price_increments),
-        .tradingHours = dxfcpp::toString(graalInstrumentProfile->trading_hours),
-        .rawCustomFields =
-            [](dxfg_string_list *strings) {
-                std::vector<std::string> result{};
-
-                if (!strings || strings->size == 0) {
-                    return result;
-                }
-
-                result.resize(strings->size);
-
-                for (std::int32_t i = 0; i < strings->size; i++) {
-                    result[i] = dxfcpp::toString(strings->elements[i]);
-                }
-
-                return result;
-            }(graalInstrumentProfile->custom_fields),
-        .customFields =
-            [](dxfg_string_list *strings) {
-                std::unordered_map<std::string, std::string> result{};
-
-                if (!strings || strings->size < 2) {
-                    return result;
-                }
-
-                for (std::int32_t i = 0; i < strings->size - 1; i += 2) {
-                    auto key = dxfcpp::toString(strings->elements[i]);
-
-                    if (key.empty()) {
-                        continue;
-                    }
-
-                    result[key] = dxfcpp::toString(strings->elements[i + 1]);
-                }
-
-                return result;
-            }(graalInstrumentProfile->custom_fields),
-    };
+    // data_ = {
+    //     .type = dxfcpp::toString(graalInstrumentProfile->type),
+    //     .symbol = dxfcpp::toString(graalInstrumentProfile->symbol),
+    //     .description = dxfcpp::toString(graalInstrumentProfile->description),
+    //     .localSymbol = dxfcpp::toString(graalInstrumentProfile->local_symbol),
+    //     .localDescription = dxfcpp::toString(graalInstrumentProfile->local_description),
+    //     .country = dxfcpp::toString(graalInstrumentProfile->country),
+    //     .opol = dxfcpp::toString(graalInstrumentProfile->opol),
+    //     .exchangeData = dxfcpp::toString(graalInstrumentProfile->exchange_data),
+    //     .exchanges = dxfcpp::toString(graalInstrumentProfile->exchanges),
+    //     .currency = dxfcpp::toString(graalInstrumentProfile->currency),
+    //     .baseCurrency = dxfcpp::toString(graalInstrumentProfile->base_currency),
+    //     .cfi = dxfcpp::toString(graalInstrumentProfile->cfi),
+    //     .isin = dxfcpp::toString(graalInstrumentProfile->isin),
+    //     .sedol = dxfcpp::toString(graalInstrumentProfile->sedol),
+    //     .cusip = dxfcpp::toString(graalInstrumentProfile->cusip),
+    //     .icb = graalInstrumentProfile->icb,
+    //     .sic = graalInstrumentProfile->sic,
+    //     .multiplier = graalInstrumentProfile->multiplier,
+    //     .product = dxfcpp::toString(graalInstrumentProfile->product),
+    //     .underlying = dxfcpp::toString(graalInstrumentProfile->underlying),
+    //     .spc = graalInstrumentProfile->spc,
+    //     .additionalUnderlyings = dxfcpp::toString(graalInstrumentProfile->additional_underlyings),
+    //     .mmy = dxfcpp::toString(graalInstrumentProfile->mmy),
+    //     .expiration = graalInstrumentProfile->expiration,
+    //     .lastTrade = graalInstrumentProfile->last_trade,
+    //     .strike = graalInstrumentProfile->strike,
+    //     .optionType = dxfcpp::toString(graalInstrumentProfile->option_type),
+    //     .expirationStyle = dxfcpp::toString(graalInstrumentProfile->expiration_style),
+    //     .settlementStyle = dxfcpp::toString(graalInstrumentProfile->settlement_style),
+    //     .priceIncrements = dxfcpp::toString(graalInstrumentProfile->price_increments),
+    //     .tradingHours = dxfcpp::toString(graalInstrumentProfile->trading_hours),
+    //     .rawCustomFields =
+    //         [](dxfg_string_list *strings) {
+    //             std::vector<std::string> result{};
+    //
+    //             if (!strings || strings->size == 0) {
+    //                 return result;
+    //             }
+    //
+    //             result.resize(strings->size);
+    //
+    //             for (std::int32_t i = 0; i < strings->size; i++) {
+    //                 result[i] = dxfcpp::toString(strings->elements[i]);
+    //             }
+    //
+    //             return result;
+    //         }(graalInstrumentProfile->custom_fields),
+    //     .customFields =
+    //         [](dxfg_string_list *strings) {
+    //             std::unordered_map<std::string, std::string> result{};
+    //
+    //             if (!strings || strings->size < 2) {
+    //                 return result;
+    //             }
+    //
+    //             for (std::int32_t i = 0; i < strings->size - 1; i += 2) {
+    //                 auto key = dxfcpp::toString(strings->elements[i]);
+    //
+    //                 if (key.empty()) {
+    //                     continue;
+    //                 }
+    //
+    //                 result[key] = dxfcpp::toString(strings->elements[i + 1]);
+    //             }
+    //
+    //             return result;
+    //         }(graalInstrumentProfile->custom_fields),
+    // };
 }
 
 void InstrumentProfile::fillGraalData(void *graalNative) const {
@@ -103,54 +103,54 @@ void InstrumentProfile::fillGraalData(void *graalNative) const {
 
     auto graalInstrumentProfile = static_cast<dxfg_instrument_profile_t *>(graalNative);
 
-    graalInstrumentProfile->type = createCString(data_.type);
-    graalInstrumentProfile->symbol = createCString(data_.symbol);
-    graalInstrumentProfile->description = createCString(data_.description);
-    graalInstrumentProfile->local_symbol = createCString(data_.localSymbol);
-    graalInstrumentProfile->local_description = createCString(data_.localDescription);
-    graalInstrumentProfile->country = createCString(data_.country);
-    graalInstrumentProfile->opol = createCString(data_.opol);
-    graalInstrumentProfile->exchange_data = createCString(data_.exchangeData);
-    graalInstrumentProfile->exchanges = createCString(data_.exchanges);
-    graalInstrumentProfile->currency = createCString(data_.currency);
-    graalInstrumentProfile->base_currency = createCString(data_.baseCurrency);
-    graalInstrumentProfile->cfi = createCString(data_.cfi);
-    graalInstrumentProfile->isin = createCString(data_.isin);
-    graalInstrumentProfile->sedol = createCString(data_.sedol);
-    graalInstrumentProfile->cusip = createCString(data_.cusip);
-    graalInstrumentProfile->icb = data_.icb;
-    graalInstrumentProfile->sic = data_.sic;
-    graalInstrumentProfile->multiplier = data_.multiplier;
-    graalInstrumentProfile->product = createCString(data_.product);
-    graalInstrumentProfile->underlying = createCString(data_.underlying);
-    graalInstrumentProfile->spc = data_.spc;
-    graalInstrumentProfile->additional_underlyings = createCString(data_.additionalUnderlyings);
-    graalInstrumentProfile->mmy = createCString(data_.mmy);
-    graalInstrumentProfile->expiration = data_.expiration;
-    graalInstrumentProfile->last_trade = data_.lastTrade;
-    graalInstrumentProfile->strike = data_.strike;
-    graalInstrumentProfile->option_type = createCString(data_.optionType);
-    graalInstrumentProfile->expiration_style = createCString(data_.expirationStyle);
-    graalInstrumentProfile->settlement_style = createCString(data_.settlementStyle);
-    graalInstrumentProfile->price_increments = createCString(data_.priceIncrements);
-    graalInstrumentProfile->trading_hours = createCString(data_.tradingHours);
-
-    if (data_.rawCustomFields.empty()) {
-        graalInstrumentProfile->custom_fields = nullptr;
-    } else {
-        graalInstrumentProfile->custom_fields = new dxfg_string_list{};
-        graalInstrumentProfile->custom_fields->size = static_cast<std::int32_t>(data_.rawCustomFields.size());
-        graalInstrumentProfile->custom_fields->elements = new const char *[data_.rawCustomFields.size()] {
-            nullptr
-        };
-
-        for (std::int32_t i = 0; i < graalInstrumentProfile->custom_fields->size; i++) {
-            // TODO: process null-strings. <null>?
-            if (!data_.rawCustomFields[i].empty()) {
-                graalInstrumentProfile->custom_fields->elements[i] = createCString(data_.rawCustomFields[i]);
-            }
-        }
-    }
+    // graalInstrumentProfile->type = createCString(data_.type);
+    // graalInstrumentProfile->symbol = createCString(data_.symbol);
+    // graalInstrumentProfile->description = createCString(data_.description);
+    // graalInstrumentProfile->local_symbol = createCString(data_.localSymbol);
+    // graalInstrumentProfile->local_description = createCString(data_.localDescription);
+    // graalInstrumentProfile->country = createCString(data_.country);
+    // graalInstrumentProfile->opol = createCString(data_.opol);
+    // graalInstrumentProfile->exchange_data = createCString(data_.exchangeData);
+    // graalInstrumentProfile->exchanges = createCString(data_.exchanges);
+    // graalInstrumentProfile->currency = createCString(data_.currency);
+    // graalInstrumentProfile->base_currency = createCString(data_.baseCurrency);
+    // graalInstrumentProfile->cfi = createCString(data_.cfi);
+    // graalInstrumentProfile->isin = createCString(data_.isin);
+    // graalInstrumentProfile->sedol = createCString(data_.sedol);
+    // graalInstrumentProfile->cusip = createCString(data_.cusip);
+    // graalInstrumentProfile->icb = data_.icb;
+    // graalInstrumentProfile->sic = data_.sic;
+    // graalInstrumentProfile->multiplier = data_.multiplier;
+    // graalInstrumentProfile->product = createCString(data_.product);
+    // graalInstrumentProfile->underlying = createCString(data_.underlying);
+    // graalInstrumentProfile->spc = data_.spc;
+    // graalInstrumentProfile->additional_underlyings = createCString(data_.additionalUnderlyings);
+    // graalInstrumentProfile->mmy = createCString(data_.mmy);
+    // graalInstrumentProfile->expiration = data_.expiration;
+    // graalInstrumentProfile->last_trade = data_.lastTrade;
+    // graalInstrumentProfile->strike = data_.strike;
+    // graalInstrumentProfile->option_type = createCString(data_.optionType);
+    // graalInstrumentProfile->expiration_style = createCString(data_.expirationStyle);
+    // graalInstrumentProfile->settlement_style = createCString(data_.settlementStyle);
+    // graalInstrumentProfile->price_increments = createCString(data_.priceIncrements);
+    // graalInstrumentProfile->trading_hours = createCString(data_.tradingHours);
+    //
+    // if (data_.rawCustomFields.empty()) {
+    //     graalInstrumentProfile->custom_fields = nullptr;
+    // } else {
+    //     graalInstrumentProfile->custom_fields = new dxfg_string_list{};
+    //     graalInstrumentProfile->custom_fields->size = static_cast<std::int32_t>(data_.rawCustomFields.size());
+    //     graalInstrumentProfile->custom_fields->elements = new const char *[data_.rawCustomFields.size()] {
+    //         nullptr
+    //     };
+    //
+    //     for (std::int32_t i = 0; i < graalInstrumentProfile->custom_fields->size; i++) {
+    //         // TODO: process null-strings. <null>?
+    //         if (!data_.rawCustomFields[i].empty()) {
+    //             graalInstrumentProfile->custom_fields->elements[i] = createCString(data_.rawCustomFields[i]);
+    //         }
+    //     }
+    // }
 }
 
 void InstrumentProfile::freeGraalData(void *graalNative) noexcept {
@@ -160,42 +160,42 @@ void InstrumentProfile::freeGraalData(void *graalNative) noexcept {
 
     auto graalInstrumentProfile = static_cast<dxfg_instrument_profile_t *>(graalNative);
 
-    delete[] graalInstrumentProfile->type;
-    delete[] graalInstrumentProfile->symbol;
-    delete[] graalInstrumentProfile->description;
-    delete[] graalInstrumentProfile->local_symbol;
-    delete[] graalInstrumentProfile->local_description;
-    delete[] graalInstrumentProfile->country;
-    delete[] graalInstrumentProfile->opol;
-    delete[] graalInstrumentProfile->exchange_data;
-    delete[] graalInstrumentProfile->exchanges;
-    delete[] graalInstrumentProfile->currency;
-    delete[] graalInstrumentProfile->base_currency;
-    delete[] graalInstrumentProfile->cfi;
-    delete[] graalInstrumentProfile->isin;
-    delete[] graalInstrumentProfile->sedol;
-    delete[] graalInstrumentProfile->cusip;
-    delete[] graalInstrumentProfile->product;
-    delete[] graalInstrumentProfile->underlying;
-    delete[] graalInstrumentProfile->additional_underlyings;
-    delete[] graalInstrumentProfile->mmy;
-    delete[] graalInstrumentProfile->option_type;
-    delete[] graalInstrumentProfile->expiration_style;
-    delete[] graalInstrumentProfile->settlement_style;
-    delete[] graalInstrumentProfile->price_increments;
-    delete[] graalInstrumentProfile->trading_hours;
-
-    if (graalInstrumentProfile->custom_fields) {
-        if (graalInstrumentProfile->custom_fields->elements && graalInstrumentProfile->custom_fields->size > 0) {
-            for (std::int32_t i = 0; i < graalInstrumentProfile->custom_fields->size; i++) {
-                delete[] graalInstrumentProfile->custom_fields->elements[i];
-            }
-
-            delete[] graalInstrumentProfile->custom_fields->elements;
-        }
-
-        delete graalInstrumentProfile->custom_fields;
-    }
+    // delete[] graalInstrumentProfile->type;
+    // delete[] graalInstrumentProfile->symbol;
+    // delete[] graalInstrumentProfile->description;
+    // delete[] graalInstrumentProfile->local_symbol;
+    // delete[] graalInstrumentProfile->local_description;
+    // delete[] graalInstrumentProfile->country;
+    // delete[] graalInstrumentProfile->opol;
+    // delete[] graalInstrumentProfile->exchange_data;
+    // delete[] graalInstrumentProfile->exchanges;
+    // delete[] graalInstrumentProfile->currency;
+    // delete[] graalInstrumentProfile->base_currency;
+    // delete[] graalInstrumentProfile->cfi;
+    // delete[] graalInstrumentProfile->isin;
+    // delete[] graalInstrumentProfile->sedol;
+    // delete[] graalInstrumentProfile->cusip;
+    // delete[] graalInstrumentProfile->product;
+    // delete[] graalInstrumentProfile->underlying;
+    // delete[] graalInstrumentProfile->additional_underlyings;
+    // delete[] graalInstrumentProfile->mmy;
+    // delete[] graalInstrumentProfile->option_type;
+    // delete[] graalInstrumentProfile->expiration_style;
+    // delete[] graalInstrumentProfile->settlement_style;
+    // delete[] graalInstrumentProfile->price_increments;
+    // delete[] graalInstrumentProfile->trading_hours;
+    //
+    // if (graalInstrumentProfile->custom_fields) {
+    //     if (graalInstrumentProfile->custom_fields->elements && graalInstrumentProfile->custom_fields->size > 0) {
+    //         for (std::int32_t i = 0; i < graalInstrumentProfile->custom_fields->size; i++) {
+    //             delete[] graalInstrumentProfile->custom_fields->elements[i];
+    //         }
+    //
+    //         delete[] graalInstrumentProfile->custom_fields->elements;
+    //     }
+    //
+    //     delete graalInstrumentProfile->custom_fields;
+    // }
 }
 
 std::shared_ptr<InstrumentProfile> InstrumentProfile::fromGraal(void *graalNative) {

--- a/src/ipf/InstrumentProfile.cpp
+++ b/src/ipf/InstrumentProfile.cpp
@@ -18,199 +18,57 @@
 
 DXFCPP_BEGIN_NAMESPACE
 
-void InstrumentProfile::fillData(void *graalNative) noexcept {
-    if (graalNative == nullptr) {
-        return;
-    }
-
-    auto graalInstrumentProfile = static_cast<dxfg_instrument_profile_t *>(graalNative);
-
-    // data_ = {
-    //     .type = dxfcpp::toString(graalInstrumentProfile->type),
-    //     .symbol = dxfcpp::toString(graalInstrumentProfile->symbol),
-    //     .description = dxfcpp::toString(graalInstrumentProfile->description),
-    //     .localSymbol = dxfcpp::toString(graalInstrumentProfile->local_symbol),
-    //     .localDescription = dxfcpp::toString(graalInstrumentProfile->local_description),
-    //     .country = dxfcpp::toString(graalInstrumentProfile->country),
-    //     .opol = dxfcpp::toString(graalInstrumentProfile->opol),
-    //     .exchangeData = dxfcpp::toString(graalInstrumentProfile->exchange_data),
-    //     .exchanges = dxfcpp::toString(graalInstrumentProfile->exchanges),
-    //     .currency = dxfcpp::toString(graalInstrumentProfile->currency),
-    //     .baseCurrency = dxfcpp::toString(graalInstrumentProfile->base_currency),
-    //     .cfi = dxfcpp::toString(graalInstrumentProfile->cfi),
-    //     .isin = dxfcpp::toString(graalInstrumentProfile->isin),
-    //     .sedol = dxfcpp::toString(graalInstrumentProfile->sedol),
-    //     .cusip = dxfcpp::toString(graalInstrumentProfile->cusip),
-    //     .icb = graalInstrumentProfile->icb,
-    //     .sic = graalInstrumentProfile->sic,
-    //     .multiplier = graalInstrumentProfile->multiplier,
-    //     .product = dxfcpp::toString(graalInstrumentProfile->product),
-    //     .underlying = dxfcpp::toString(graalInstrumentProfile->underlying),
-    //     .spc = graalInstrumentProfile->spc,
-    //     .additionalUnderlyings = dxfcpp::toString(graalInstrumentProfile->additional_underlyings),
-    //     .mmy = dxfcpp::toString(graalInstrumentProfile->mmy),
-    //     .expiration = graalInstrumentProfile->expiration,
-    //     .lastTrade = graalInstrumentProfile->last_trade,
-    //     .strike = graalInstrumentProfile->strike,
-    //     .optionType = dxfcpp::toString(graalInstrumentProfile->option_type),
-    //     .expirationStyle = dxfcpp::toString(graalInstrumentProfile->expiration_style),
-    //     .settlementStyle = dxfcpp::toString(graalInstrumentProfile->settlement_style),
-    //     .priceIncrements = dxfcpp::toString(graalInstrumentProfile->price_increments),
-    //     .tradingHours = dxfcpp::toString(graalInstrumentProfile->trading_hours),
-    //     .rawCustomFields =
-    //         [](dxfg_string_list *strings) {
-    //             std::vector<std::string> result{};
-    //
-    //             if (!strings || strings->size == 0) {
-    //                 return result;
-    //             }
-    //
-    //             result.resize(strings->size);
-    //
-    //             for (std::int32_t i = 0; i < strings->size; i++) {
-    //                 result[i] = dxfcpp::toString(strings->elements[i]);
-    //             }
-    //
-    //             return result;
-    //         }(graalInstrumentProfile->custom_fields),
-    //     .customFields =
-    //         [](dxfg_string_list *strings) {
-    //             std::unordered_map<std::string, std::string> result{};
-    //
-    //             if (!strings || strings->size < 2) {
-    //                 return result;
-    //             }
-    //
-    //             for (std::int32_t i = 0; i < strings->size - 1; i += 2) {
-    //                 auto key = dxfcpp::toString(strings->elements[i]);
-    //
-    //                 if (key.empty()) {
-    //                     continue;
-    //                 }
-    //
-    //                 result[key] = dxfcpp::toString(strings->elements[i + 1]);
-    //             }
-    //
-    //             return result;
-    //         }(graalInstrumentProfile->custom_fields),
-    // };
+InstrumentProfile::Ptr InstrumentProfile::create() {
+    return createShared(isolated::ipf::IsolatedInstrumentProfile::create());
 }
 
-void InstrumentProfile::fillGraalData(void *graalNative) const {
-    if (graalNative == nullptr) {
-        return;
-    }
-
-    auto graalInstrumentProfile = static_cast<dxfg_instrument_profile_t *>(graalNative);
-
-    // graalInstrumentProfile->type = createCString(data_.type);
-    // graalInstrumentProfile->symbol = createCString(data_.symbol);
-    // graalInstrumentProfile->description = createCString(data_.description);
-    // graalInstrumentProfile->local_symbol = createCString(data_.localSymbol);
-    // graalInstrumentProfile->local_description = createCString(data_.localDescription);
-    // graalInstrumentProfile->country = createCString(data_.country);
-    // graalInstrumentProfile->opol = createCString(data_.opol);
-    // graalInstrumentProfile->exchange_data = createCString(data_.exchangeData);
-    // graalInstrumentProfile->exchanges = createCString(data_.exchanges);
-    // graalInstrumentProfile->currency = createCString(data_.currency);
-    // graalInstrumentProfile->base_currency = createCString(data_.baseCurrency);
-    // graalInstrumentProfile->cfi = createCString(data_.cfi);
-    // graalInstrumentProfile->isin = createCString(data_.isin);
-    // graalInstrumentProfile->sedol = createCString(data_.sedol);
-    // graalInstrumentProfile->cusip = createCString(data_.cusip);
-    // graalInstrumentProfile->icb = data_.icb;
-    // graalInstrumentProfile->sic = data_.sic;
-    // graalInstrumentProfile->multiplier = data_.multiplier;
-    // graalInstrumentProfile->product = createCString(data_.product);
-    // graalInstrumentProfile->underlying = createCString(data_.underlying);
-    // graalInstrumentProfile->spc = data_.spc;
-    // graalInstrumentProfile->additional_underlyings = createCString(data_.additionalUnderlyings);
-    // graalInstrumentProfile->mmy = createCString(data_.mmy);
-    // graalInstrumentProfile->expiration = data_.expiration;
-    // graalInstrumentProfile->last_trade = data_.lastTrade;
-    // graalInstrumentProfile->strike = data_.strike;
-    // graalInstrumentProfile->option_type = createCString(data_.optionType);
-    // graalInstrumentProfile->expiration_style = createCString(data_.expirationStyle);
-    // graalInstrumentProfile->settlement_style = createCString(data_.settlementStyle);
-    // graalInstrumentProfile->price_increments = createCString(data_.priceIncrements);
-    // graalInstrumentProfile->trading_hours = createCString(data_.tradingHours);
-    //
-    // if (data_.rawCustomFields.empty()) {
-    //     graalInstrumentProfile->custom_fields = nullptr;
-    // } else {
-    //     graalInstrumentProfile->custom_fields = new dxfg_string_list{};
-    //     graalInstrumentProfile->custom_fields->size = static_cast<std::int32_t>(data_.rawCustomFields.size());
-    //     graalInstrumentProfile->custom_fields->elements = new const char *[data_.rawCustomFields.size()] {
-    //         nullptr
-    //     };
-    //
-    //     for (std::int32_t i = 0; i < graalInstrumentProfile->custom_fields->size; i++) {
-    //         // TODO: process null-strings. <null>?
-    //         if (!data_.rawCustomFields[i].empty()) {
-    //             graalInstrumentProfile->custom_fields->elements[i] = createCString(data_.rawCustomFields[i]);
-    //         }
-    //     }
-    // }
+InstrumentProfile::Ptr InstrumentProfile::create(Ptr ip) {
+    return createShared(isolated::ipf::IsolatedInstrumentProfile::create(ip->handle_));
 }
 
-void InstrumentProfile::freeGraalData(void *graalNative) noexcept {
-    if (graalNative == nullptr) {
-        return;
-    }
-
-    auto graalInstrumentProfile = static_cast<dxfg_instrument_profile_t *>(graalNative);
-
-    // delete[] graalInstrumentProfile->type;
-    // delete[] graalInstrumentProfile->symbol;
-    // delete[] graalInstrumentProfile->description;
-    // delete[] graalInstrumentProfile->local_symbol;
-    // delete[] graalInstrumentProfile->local_description;
-    // delete[] graalInstrumentProfile->country;
-    // delete[] graalInstrumentProfile->opol;
-    // delete[] graalInstrumentProfile->exchange_data;
-    // delete[] graalInstrumentProfile->exchanges;
-    // delete[] graalInstrumentProfile->currency;
-    // delete[] graalInstrumentProfile->base_currency;
-    // delete[] graalInstrumentProfile->cfi;
-    // delete[] graalInstrumentProfile->isin;
-    // delete[] graalInstrumentProfile->sedol;
-    // delete[] graalInstrumentProfile->cusip;
-    // delete[] graalInstrumentProfile->product;
-    // delete[] graalInstrumentProfile->underlying;
-    // delete[] graalInstrumentProfile->additional_underlyings;
-    // delete[] graalInstrumentProfile->mmy;
-    // delete[] graalInstrumentProfile->option_type;
-    // delete[] graalInstrumentProfile->expiration_style;
-    // delete[] graalInstrumentProfile->settlement_style;
-    // delete[] graalInstrumentProfile->price_increments;
-    // delete[] graalInstrumentProfile->trading_hours;
-    //
-    // if (graalInstrumentProfile->custom_fields) {
-    //     if (graalInstrumentProfile->custom_fields->elements && graalInstrumentProfile->custom_fields->size > 0) {
-    //         for (std::int32_t i = 0; i < graalInstrumentProfile->custom_fields->size; i++) {
-    //             delete[] graalInstrumentProfile->custom_fields->elements[i];
-    //         }
-    //
-    //         delete[] graalInstrumentProfile->custom_fields->elements;
-    //     }
-    //
-    //     delete graalInstrumentProfile->custom_fields;
-    // }
+std::string InstrumentProfile::getType() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getType(handle_);
 }
 
-std::shared_ptr<InstrumentProfile> InstrumentProfile::fromGraal(void *graalNative) {
-    if (!graalNative) {
-        throw std::invalid_argument("Unable to create InstrumentProfile. The `graalNative` parameter is nullptr");
-    }
-
-    auto instrumentProfile = std::make_shared<InstrumentProfile>();
-
-    instrumentProfile->fillData(graalNative);
-
-    return instrumentProfile;
+void InstrumentProfile::setType(const StringLikeWrapper &type) const {
+    isolated::ipf::IsolatedInstrumentProfile::setType(handle_, type);
 }
 
-std::vector<std::shared_ptr<InstrumentProfile>> InstrumentProfile::fromGraalList(void *graalList) {
+std::string InstrumentProfile::getSymbol() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getSymbol(handle_);
+}
+
+void InstrumentProfile::setSymbol(const StringLikeWrapper &symbol) const {
+    isolated::ipf::IsolatedInstrumentProfile::setSymbol(handle_, symbol);
+}
+
+std::string InstrumentProfile::getDescription() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getDescription(handle_);
+}
+
+void InstrumentProfile::setDescription(const StringLikeWrapper &description) const {
+    isolated::ipf::IsolatedInstrumentProfile::setDescription(handle_, description);
+}
+
+
+std::string InstrumentProfile::getLocalSymbol() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getLocalSymbol(handle_);
+}
+
+void InstrumentProfile::setLocalSymbol(const StringLikeWrapper &localSymbol) const {
+    isolated::ipf::IsolatedInstrumentProfile::setLocalSymbol(handle_, localSymbol);
+}
+
+InstrumentProfile::~InstrumentProfile() noexcept {}
+
+InstrumentProfile::InstrumentProfile(LockExternalConstructionTag, JavaObjectHandle<InstrumentProfile> &&handle) : handle_(std::move(handle)) {
+}
+
+InstrumentProfile::Ptr InstrumentProfile::create(JavaObjectHandle<InstrumentProfile> &&handle) {
+    return createShared(std::move(handle));
+}
+
+std::vector<std::shared_ptr<InstrumentProfile>> InstrumentProfile::List::fromGraal(void *graalList) {
     using ListType = dxfg_instrument_profile_list;
     using SizeType = decltype(ListType::size);
 
@@ -220,7 +78,7 @@ std::vector<std::shared_ptr<InstrumentProfile>> InstrumentProfile::fromGraalList
 
     std::vector<std::shared_ptr<InstrumentProfile>> result{};
 
-    auto list = static_cast<ListType *>(graalList);
+    const auto list = static_cast<ListType *>(graalList);
 
     if (list->size <= 0 || list->elements == nullptr) {
         return result;
@@ -228,31 +86,11 @@ std::vector<std::shared_ptr<InstrumentProfile>> InstrumentProfile::fromGraalList
 
     for (SizeType elementIndex = 0; elementIndex < list->size; elementIndex++) {
         if (list->elements[elementIndex]) {
-            result.emplace_back(InstrumentProfile::fromGraal(static_cast<void *>(list->elements[elementIndex])));
+            result.emplace_back(create(JavaObjectHandle<InstrumentProfile>(list->elements[elementIndex])));
         }
     }
 
     return result;
-}
-
-void *InstrumentProfile::toGraal() const {
-    auto *graalInstrumentProfile = new dxfg_instrument_profile_t{};
-
-    fillGraalData(static_cast<void *>(graalInstrumentProfile));
-
-    return static_cast<void *>(graalInstrumentProfile);
-}
-
-void InstrumentProfile::freeGraal(void *graalNative) {
-    if (!graalNative) {
-        return;
-    }
-
-    auto graalInstrumentProfile = static_cast<dxfg_instrument_profile_t *>(graalNative);
-
-    freeGraalData(graalNative);
-
-    delete graalInstrumentProfile;
 }
 
 DXFCPP_END_NAMESPACE

--- a/src/ipf/InstrumentProfile.cpp
+++ b/src/ipf/InstrumentProfile.cpp
@@ -50,7 +50,6 @@ void InstrumentProfile::setDescription(const StringLikeWrapper &description) con
     isolated::ipf::IsolatedInstrumentProfile::setDescription(handle_, description);
 }
 
-
 std::string InstrumentProfile::getLocalSymbol() const {
     return isolated::ipf::IsolatedInstrumentProfile::getLocalSymbol(handle_);
 }
@@ -59,9 +58,283 @@ void InstrumentProfile::setLocalSymbol(const StringLikeWrapper &localSymbol) con
     isolated::ipf::IsolatedInstrumentProfile::setLocalSymbol(handle_, localSymbol);
 }
 
-InstrumentProfile::~InstrumentProfile() noexcept {}
+std::string InstrumentProfile::getLocalDescription() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getLocalDescription(handle_);
+}
 
-InstrumentProfile::InstrumentProfile(LockExternalConstructionTag, JavaObjectHandle<InstrumentProfile> &&handle) : handle_(std::move(handle)) {
+void InstrumentProfile::setLocalDescription(const StringLikeWrapper &localDescription) const {
+    isolated::ipf::IsolatedInstrumentProfile::setLocalDescription(handle_, localDescription);
+}
+
+std::string InstrumentProfile::getCountry() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getCountry(handle_);
+}
+
+void InstrumentProfile::setCountry(const StringLikeWrapper &country) const {
+    isolated::ipf::IsolatedInstrumentProfile::setCountry(handle_, country);
+}
+
+std::string InstrumentProfile::getOPOL() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getOPOL(handle_);
+}
+
+void InstrumentProfile::setOPOL(const StringLikeWrapper &opol) const {
+    isolated::ipf::IsolatedInstrumentProfile::setOPOL(handle_, opol);
+}
+
+std::string InstrumentProfile::getExchangeData() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getExchangeData(handle_);
+}
+
+void InstrumentProfile::setExchangeData(const StringLikeWrapper &exchangeData) const {
+    isolated::ipf::IsolatedInstrumentProfile::setExchangeData(handle_, exchangeData);
+}
+
+std::string InstrumentProfile::getExchanges() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getExchanges(handle_);
+}
+
+void InstrumentProfile::setExchanges(const StringLikeWrapper &exchanges) const {
+    isolated::ipf::IsolatedInstrumentProfile::setExchanges(handle_, exchanges);
+}
+
+std::string InstrumentProfile::getCurrency() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getCurrency(handle_);
+}
+
+void InstrumentProfile::setCurrency(const StringLikeWrapper &currency) const {
+    isolated::ipf::IsolatedInstrumentProfile::setCurrency(handle_, currency);
+}
+
+std::string InstrumentProfile::getBaseCurrency() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getBaseCurrency(handle_);
+}
+
+void InstrumentProfile::setBaseCurrency(const StringLikeWrapper &baseCurrency) const {
+    isolated::ipf::IsolatedInstrumentProfile::setBaseCurrency(handle_, baseCurrency);
+}
+
+std::string InstrumentProfile::getCFI() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getCFI(handle_);
+}
+
+void InstrumentProfile::setCFI(const StringLikeWrapper &cfi) const {
+    isolated::ipf::IsolatedInstrumentProfile::setCFI(handle_, cfi);
+}
+
+std::string InstrumentProfile::getISIN() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getISIN(handle_);
+}
+
+void InstrumentProfile::setISIN(const StringLikeWrapper &isin) const {
+    isolated::ipf::IsolatedInstrumentProfile::setISIN(handle_, isin);
+}
+
+std::string InstrumentProfile::getSEDOL() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getSEDOL(handle_);
+}
+
+void InstrumentProfile::setSEDOL(const StringLikeWrapper &sedol) const {
+    isolated::ipf::IsolatedInstrumentProfile::setSEDOL(handle_, sedol);
+}
+
+std::string InstrumentProfile::getCUSIP() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getCUSIP(handle_);
+}
+
+void InstrumentProfile::setCUSIP(const StringLikeWrapper &cusip) const {
+    isolated::ipf::IsolatedInstrumentProfile::setCUSIP(handle_, cusip);
+}
+
+std::int32_t InstrumentProfile::getICB() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getICB(handle_);
+}
+
+void InstrumentProfile::setICB(std::int32_t icb) const {
+    isolated::ipf::IsolatedInstrumentProfile::setICB(handle_, icb);
+}
+
+std::int32_t InstrumentProfile::getSIC() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getSIC(handle_);
+}
+
+void InstrumentProfile::setSIC(std::int32_t sic) const {
+    isolated::ipf::IsolatedInstrumentProfile::setSIC(handle_, sic);
+}
+
+double InstrumentProfile::getMultiplier() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getMultiplier(handle_);
+}
+
+void InstrumentProfile::setMultiplier(double multiplier) const {
+    isolated::ipf::IsolatedInstrumentProfile::setMultiplier(handle_, multiplier);
+}
+
+std::string InstrumentProfile::getProduct() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getProduct(handle_);
+}
+
+void InstrumentProfile::setProduct(const StringLikeWrapper &product) const {
+    isolated::ipf::IsolatedInstrumentProfile::setProduct(handle_, product);
+}
+
+std::string InstrumentProfile::getUnderlying() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getUnderlying(handle_);
+}
+
+void InstrumentProfile::setUnderlying(const StringLikeWrapper &underlying) const {
+    isolated::ipf::IsolatedInstrumentProfile::setUnderlying(handle_, underlying);
+}
+
+double InstrumentProfile::getSPC() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getSPC(handle_);
+}
+
+void InstrumentProfile::setSPC(double spc) const {
+    isolated::ipf::IsolatedInstrumentProfile::setSPC(handle_, spc);
+}
+
+std::string InstrumentProfile::getAdditionalUnderlyings() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getAdditionalUnderlyings(handle_);
+}
+
+void InstrumentProfile::setAdditionalUnderlyings(const StringLikeWrapper &additionalUnderlyings) const {
+    isolated::ipf::IsolatedInstrumentProfile::setAdditionalUnderlyings(handle_, additionalUnderlyings);
+}
+
+std::string InstrumentProfile::getMMY() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getMMY(handle_);
+}
+
+void InstrumentProfile::setMMY(const StringLikeWrapper &mmy) const {
+    isolated::ipf::IsolatedInstrumentProfile::setMMY(handle_, mmy);
+}
+
+std::int32_t InstrumentProfile::getExpiration() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getExpiration(handle_);
+}
+
+void InstrumentProfile::setExpiration(std::int32_t expiration) const {
+    isolated::ipf::IsolatedInstrumentProfile::setExpiration(handle_, expiration);
+}
+
+std::int32_t InstrumentProfile::getLastTrade() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getLastTrade(handle_);
+}
+
+void InstrumentProfile::setLastTrade(std::int32_t lastTrade) const {
+    isolated::ipf::IsolatedInstrumentProfile::setLastTrade(handle_, lastTrade);
+}
+
+double InstrumentProfile::getStrike() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getStrike(handle_);
+}
+
+void InstrumentProfile::setStrike(double strike) const {
+    isolated::ipf::IsolatedInstrumentProfile::setStrike(handle_, strike);
+}
+
+std::string InstrumentProfile::getOptionType() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getOptionType(handle_);
+}
+
+void InstrumentProfile::setOptionType(const StringLikeWrapper &optionType) const {
+    isolated::ipf::IsolatedInstrumentProfile::setOptionType(handle_, optionType);
+}
+
+std::string InstrumentProfile::getExpirationStyle() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getExpirationStyle(handle_);
+}
+
+void InstrumentProfile::setExpirationStyle(const StringLikeWrapper &expirationStyle) const {
+    isolated::ipf::IsolatedInstrumentProfile::setExpirationStyle(handle_, expirationStyle);
+}
+
+std::string InstrumentProfile::getSettlementStyle() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getSettlementStyle(handle_);
+}
+
+void InstrumentProfile::setSettlementStyle(const StringLikeWrapper &settlementStyle) const {
+    isolated::ipf::IsolatedInstrumentProfile::setSettlementStyle(handle_, settlementStyle);
+}
+
+std::string InstrumentProfile::getPriceIncrements() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getPriceIncrements(handle_);
+}
+
+void InstrumentProfile::setPriceIncrements(const StringLikeWrapper &priceIncrements) const {
+    isolated::ipf::IsolatedInstrumentProfile::setPriceIncrements(handle_, priceIncrements);
+}
+
+std::string InstrumentProfile::getTradingHours() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getTradingHours(handle_);
+}
+
+void InstrumentProfile::setTradingHours(const StringLikeWrapper &tradingHours) const {
+    isolated::ipf::IsolatedInstrumentProfile::setTradingHours(handle_, tradingHours);
+}
+
+std::string InstrumentProfile::getField(const StringLikeWrapper &name) const {
+    return isolated::ipf::IsolatedInstrumentProfile::getField(handle_, name);
+}
+
+void InstrumentProfile::setField(const StringLikeWrapper &name, const StringLikeWrapper &value) const {
+    isolated::ipf::IsolatedInstrumentProfile::setField(handle_, name, value);
+}
+
+double InstrumentProfile::getNumericField(const StringLikeWrapper &name) const {
+    return isolated::ipf::IsolatedInstrumentProfile::getNumericField(handle_, name);
+}
+
+void InstrumentProfile::setNumericField(const StringLikeWrapper &name, double value) const {
+    isolated::ipf::IsolatedInstrumentProfile::setNumericField(handle_, name, value);
+}
+
+std::int32_t InstrumentProfile::getDateField(const StringLikeWrapper &name) const {
+    return isolated::ipf::IsolatedInstrumentProfile::getDateField(handle_, name);
+}
+
+void InstrumentProfile::setDateField(const StringLikeWrapper &name, std::int32_t value) const {
+    isolated::ipf::IsolatedInstrumentProfile::setDateField(handle_, name, value);
+}
+
+std::vector<std::string> InstrumentProfile::getNonEmptyCustomFieldNames() const {
+    return isolated::ipf::IsolatedInstrumentProfile::getNonEmptyCustomFieldNames(handle_);
+}
+
+std::string InstrumentProfile::toString() const {
+    if (!handle_) {
+        return "InstrumentProfile{<null>}";
+    }
+
+    return isolated::internal::IsolatedObject::toString(handle_.get());
+}
+
+std::size_t InstrumentProfile::hashCode() const {
+    if (!handle_) {
+        return 0;
+    }
+
+    return isolated::internal::IsolatedObject::hashCode(handle_.get());
+}
+
+bool InstrumentProfile::operator==(const InstrumentProfile &other) const {
+    if (!handle_) {
+        return !other.handle_;
+    }
+
+    if (!other.handle_) {
+        return false;
+    }
+
+    return isolated::internal::IsolatedObject::equals(handle_.get(), other.handle_.get()) == 0;
+}
+
+InstrumentProfile::~InstrumentProfile() noexcept {
+}
+
+InstrumentProfile::InstrumentProfile(LockExternalConstructionTag, JavaObjectHandle<InstrumentProfile> &&handle)
+    : handle_(std::move(handle)) {
 }
 
 InstrumentProfile::Ptr InstrumentProfile::create(JavaObjectHandle<InstrumentProfile> &&handle) {

--- a/src/ipf/InstrumentProfileReader.cpp
+++ b/src/ipf/InstrumentProfileReader.cpp
@@ -44,10 +44,9 @@ std::string InstrumentProfileReader::resolveSourceURL(const StringLikeWrapper &a
 
 std::vector<std::shared_ptr<InstrumentProfile>>
 InstrumentProfileReader::readFromFile(const StringLikeWrapper &address) const {
-    auto *list = dxfcpp::isolated::ipf::IsolatedInstrumentProfileReader::readFromFile(handle_, address);
-    auto result = InstrumentProfile::fromGraalList(list);
-
-    dxfcpp::isolated::ipf::InstrumentProfileList::release(list);
+    const auto list = isolated::ipf::IsolatedInstrumentProfileList::toUniqueWrapper(
+        isolated::ipf::IsolatedInstrumentProfileReader::readFromFile(handle_, address));
+    auto result = InstrumentProfile::List::fromGraal(list.get());
 
     return result;
 }
@@ -55,20 +54,18 @@ InstrumentProfileReader::readFromFile(const StringLikeWrapper &address) const {
 std::vector<std::shared_ptr<InstrumentProfile>>
 InstrumentProfileReader::readFromFile(const StringLikeWrapper &address, const StringLikeWrapper &user,
                                       const StringLikeWrapper &password) const {
-    auto *list = dxfcpp::isolated::ipf::IsolatedInstrumentProfileReader::readFromFile(handle_, address, user, password);
-    auto result = InstrumentProfile::fromGraalList(list);
-
-    dxfcpp::isolated::ipf::InstrumentProfileList::release(list);
+    const auto list = isolated::ipf::IsolatedInstrumentProfileList::toUniqueWrapper(
+        isolated::ipf::IsolatedInstrumentProfileReader::readFromFile(handle_, address, user, password));
+    auto result = InstrumentProfile::List::fromGraal(list.get());
 
     return result;
 }
 
 std::vector<std::shared_ptr<InstrumentProfile>> InstrumentProfileReader::readFromFile(const StringLikeWrapper &address,
                                                                                       const AuthToken &token) const {
-    auto *list = dxfcpp::isolated::ipf::IsolatedInstrumentProfileReader::readFromFile(handle_, address, token.handle_);
-    auto result = InstrumentProfile::fromGraalList(list);
-
-    dxfcpp::isolated::ipf::InstrumentProfileList::release(list);
+    const auto list = isolated::ipf::IsolatedInstrumentProfileList::toUniqueWrapper(
+        isolated::ipf::IsolatedInstrumentProfileReader::readFromFile(handle_, address, token.handle_));
+    auto result = InstrumentProfile::List::fromGraal(list.get());
 
     return result;
 }

--- a/src/ipf/live/InstrumentProfileCollector.cpp
+++ b/src/ipf/live/InstrumentProfileCollector.cpp
@@ -36,8 +36,7 @@ struct NonOwningInstrumentProfileIterator {
         }
 
         auto graalProfile = isolated::ipf::InstrumentProfileIterator::next(iterable);
-        auto result = InstrumentProfile::fromGraal(graalProfile);
-        isolated::ipf::InstrumentProfile::release(graalProfile);
+        auto result = InstrumentProfile::create(JavaObjectHandle<InstrumentProfile>(graalProfile));
 
         return result;
     };
@@ -154,27 +153,7 @@ void InstrumentProfileCollector::updateInstrumentProfile(std::shared_ptr<Instrum
         return;
     }
 
-    auto graal = ip->toGraal();
-
-    if (graal) {
-        dxfcpp::isolated::ipf::InstrumentProfileCollector::updateInstrumentProfile(handle_.get(), graal);
-
-        InstrumentProfile::freeGraal(graal);
-    }
-}
-
-void InstrumentProfileCollector::updateInstrumentProfile(const InstrumentProfile &ip) const {
-    if (!handle_) {
-        return;
-    }
-
-    auto graal = ip.toGraal();
-
-    if (graal) {
-        dxfcpp::isolated::ipf::InstrumentProfileCollector::updateInstrumentProfile(handle_.get(), graal);
-
-        InstrumentProfile::freeGraal(graal);
-    }
+    isolated::ipf::InstrumentProfileCollector::updateInstrumentProfile(handle_.get(), ip->handle_.get());
 }
 
 std::shared_ptr<IterableInstrumentProfile> InstrumentProfileCollector::view() const noexcept {

--- a/src/ipf/live/IterableInstrumentProfile.cpp
+++ b/src/ipf/live/IterableInstrumentProfile.cpp
@@ -21,7 +21,7 @@ DXFCPP_BEGIN_NAMESPACE
 IterableInstrumentProfile::IterableInstrumentProfile(void *handle) noexcept : handle_(handle) {
 }
 
-std::shared_ptr<IterableInstrumentProfile> IterableInstrumentProfile::create(void* handle) noexcept {
+std::shared_ptr<IterableInstrumentProfile> IterableInstrumentProfile::create(void *handle) noexcept {
     return std::shared_ptr<IterableInstrumentProfile>(new IterableInstrumentProfile(handle));
 }
 
@@ -39,8 +39,7 @@ std::shared_ptr<IterableInstrumentProfile> IterableInstrumentProfile::create(voi
     }
 
     auto graalProfile = isolated::ipf::InstrumentProfileIterator::next(handle_.get());
-    auto result = InstrumentProfile::fromGraal(graalProfile);
-    isolated::ipf::InstrumentProfile::release(graalProfile);
+    auto result = InstrumentProfile::create(JavaObjectHandle<InstrumentProfile>(graalProfile));
 
     return result;
 };

--- a/src/isolated/internal/IsolatedString.cpp
+++ b/src/isolated/internal/IsolatedString.cpp
@@ -13,11 +13,20 @@ namespace isolated::internal {
 namespace IsolatedString {
 
 bool release(const char *string) {
+    std::cerr << 222 << std::endl;
+    std::cerr << toString(string) << std::endl;
+
     if (!string) {
         throw std::invalid_argument("Unable to execute function `dxfg_String_release`. The `string` is nullptr");
     }
 
     return runGraalFunctionAndThrowIfLessThanZero(dxfg_String_release, string) == 0;
+}
+
+std::unique_ptr<const char, decltype(&release)> toUnique(const char *string) {
+std::cerr << 111 << std::endl;
+
+    return {string, release};
 }
 
 } // namespace IsolatedString

--- a/src/isolated/internal/IsolatedString.cpp
+++ b/src/isolated/internal/IsolatedString.cpp
@@ -13,9 +13,6 @@ namespace isolated::internal {
 namespace IsolatedString {
 
 bool release(const char *string) {
-    std::cerr << 222 << std::endl;
-    std::cerr << toString(string) << std::endl;
-
     if (!string) {
         throw std::invalid_argument("Unable to execute function `dxfg_String_release`. The `string` is nullptr");
     }
@@ -24,8 +21,6 @@ bool release(const char *string) {
 }
 
 std::unique_ptr<const char, decltype(&release)> toUnique(const char *string) {
-std::cerr << 111 << std::endl;
-
     return {string, release};
 }
 
@@ -41,6 +36,10 @@ bool release(/* dxfg_string_list* */ void *stringList) {
 
     return runGraalFunctionAndThrowIfLessThanZero(dxfg_CList_String_release,
                                                   static_cast<dxfg_string_list *>(stringList));
+}
+
+std::unique_ptr<void, decltype(&release)> toUnique(void *stringList) {
+    return {stringList, release};
 }
 
 } // namespace IsolatedStringList

--- a/src/isolated/ipf/IsolatedInstrumentProfile.cpp
+++ b/src/isolated/ipf/IsolatedInstrumentProfile.cpp
@@ -50,8 +50,8 @@ create(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile
             "Unable to execute function `dxfg_InstrumentProfile_setType`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setType,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setType,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getSymbol
@@ -77,8 +77,8 @@ getSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProf
             "Unable to execute function `dxfg_InstrumentProfile_setSymbol`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setSymbol,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setSymbol,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getDescription
@@ -104,8 +104,8 @@ getDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrumen
             "Unable to execute function `dxfg_InstrumentProfile_setDescription`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setDescription,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setDescription,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getLocalSymbol
@@ -131,8 +131,8 @@ getLocalSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrumen
             "Unable to execute function `dxfg_InstrumentProfile_setLocalSymbol`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setLocalSymbol,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setLocalSymbol,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getLocalDescription
@@ -159,8 +159,8 @@ setLocalDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Inst
             "Unable to execute function `dxfg_InstrumentProfile_setLocalDescription`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setLocalDescription,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setLocalDescription,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getCountry
@@ -186,8 +186,8 @@ getCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPro
             "Unable to execute function `dxfg_InstrumentProfile_setCountry`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setCountry,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setCountry,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getOPOL
@@ -212,8 +212,8 @@ getCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPro
             "Unable to execute function `dxfg_InstrumentProfile_setOPOL`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setOPOL,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setOPOL,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getExchangeData
@@ -239,8 +239,8 @@ getExchangeData(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
             "Unable to execute function `dxfg_InstrumentProfile_setExchangeData`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setExchangeData,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setExchangeData,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getExchanges
@@ -266,8 +266,8 @@ getExchanges(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentP
             "Unable to execute function `dxfg_InstrumentProfile_setExchanges`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setExchanges,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setExchanges,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getCurrency
@@ -293,8 +293,8 @@ getCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPr
             "Unable to execute function `dxfg_InstrumentProfile_setCurrency`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setCurrency,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setCurrency,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getBaseCurrency
@@ -320,8 +320,8 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
             "Unable to execute function `dxfg_InstrumentProfile_setBaseCurrency`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setBaseCurrency,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setBaseCurrency,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getCFI
@@ -346,8 +346,8 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
             "Unable to execute function `dxfg_InstrumentProfile_setCFI`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setCFI,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setCFI,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getISIN
@@ -372,8 +372,8 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
             "Unable to execute function `dxfg_InstrumentProfile_setISIN`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setISIN,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setISIN,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getSEDOL
@@ -398,8 +398,8 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
             "Unable to execute function `dxfg_InstrumentProfile_setSEDOL`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setSEDOL,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setSEDOL,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
 }
 
 // dxfg_InstrumentProfile_getCUSIP
@@ -424,8 +424,516 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
             "Unable to execute function `dxfg_InstrumentProfile_setCUSIP`. The ip handle is invalid");
     }
 
-    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setCUSIP,
-                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setCUSIP,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getICB
+std::int32_t getICB(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getICB`. The ip handle is invalid");
+    }
+
+    return runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_getICB,
+                                              static_cast<dxfg_instrument_profile_t *>(ip.get()));
+}
+
+// dxfg_InstrumentProfile_setICB
+/* std::int32_t */ void setICB(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               std::int32_t value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setICB`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setICB,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value);
+}
+
+// dxfg_InstrumentProfile_getSIC
+std::int32_t getSIC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getSIC`. The ip handle is invalid");
+    }
+
+    return runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_getSIC,
+                                              static_cast<dxfg_instrument_profile_t *>(ip.get()));
+}
+
+// dxfg_InstrumentProfile_setSIC
+/* std::int32_t */ void setSIC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               std::int32_t value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setSIC`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setSIC,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value);
+}
+
+// dxfg_InstrumentProfile_getMultiplier
+double getMultiplier(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getMultiplier`. The ip handle is invalid");
+    }
+
+    return runGraalFunctionAndThrowIfMinusInf(dxfg_InstrumentProfile_getMultiplier,
+                                              static_cast<dxfg_instrument_profile_t *>(ip.get()));
+}
+
+// dxfg_InstrumentProfile_setMultiplier
+/* std::int32_t */ void setMultiplier(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                      double value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setMultiplier`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setMultiplier,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value);
+}
+
+// dxfg_InstrumentProfile_getProduct
+/* const char* */ std::string
+getProduct(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getProduct`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getProduct, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setProduct
+/* std::int32_t */ void setProduct(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                   const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setProduct`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setProduct,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getUnderlying
+/* const char* */ std::string
+getUnderlying(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getUnderlying`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getUnderlying, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setUnderlying
+/* std::int32_t */ void setUnderlying(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                      const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setUnderlying`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setUnderlying,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getSPC
+double getSPC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getSPC`. The ip handle is invalid");
+    }
+
+    return runGraalFunctionAndThrowIfMinusInf(dxfg_InstrumentProfile_getSPC,
+                                              static_cast<dxfg_instrument_profile_t *>(ip.get()));
+}
+
+// dxfg_InstrumentProfile_setSPC
+/* std::int32_t */ void setSPC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               double value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setSPC`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setSPC,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value);
+}
+
+// dxfg_InstrumentProfile_getAdditionalUnderlyings
+/* const char* */ std::string
+getAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getAdditionalUnderlyings`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getAdditionalUnderlyings, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setAdditionalUnderlyings
+/* std::int32_t */ void
+setAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                         const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setAdditionalUnderlyings`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setAdditionalUnderlyings,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getMMY
+/* const char* */ std::string getMMY(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getMMY`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getMMY, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setMMY
+/* std::int32_t */ void setMMY(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setMMY`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setMMY,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getExpiration
+std::int32_t getExpiration(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getExpiration`. The ip handle is invalid");
+    }
+
+    return runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_getExpiration,
+                                              static_cast<dxfg_instrument_profile_t *>(ip.get()));
+}
+
+// dxfg_InstrumentProfile_setExpiration
+/* std::int32_t */ void setExpiration(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                      std::int32_t value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setExpiration`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setExpiration,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value);
+}
+
+// dxfg_InstrumentProfile_getLastTrade
+std::int32_t getLastTrade(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getLastTrade`. The ip handle is invalid");
+    }
+
+    return runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_getLastTrade,
+                                              static_cast<dxfg_instrument_profile_t *>(ip.get()));
+}
+
+// dxfg_InstrumentProfile_setLastTrade
+/* std::int32_t */ void setLastTrade(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                     std::int32_t value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setLastTrade`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setLastTrade,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value);
+}
+
+// dxfg_InstrumentProfile_getStrike
+double getStrike(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getStrike`. The ip handle is invalid");
+    }
+
+    return runGraalFunctionAndThrowIfMinusInf(dxfg_InstrumentProfile_getStrike,
+                                              static_cast<dxfg_instrument_profile_t *>(ip.get()));
+}
+
+// dxfg_InstrumentProfile_setStrike
+/* std::int32_t */ void setStrike(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                  double value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setStrike`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setStrike,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value);
+}
+
+// dxfg_InstrumentProfile_getOptionType
+/* const char* */ std::string
+getOptionType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getOptionType`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getOptionType, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setOptionType
+/* std::int32_t */ void setOptionType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                      const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setOptionType`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setOptionType,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getExpirationStyle
+/* const char* */ std::string
+getExpirationStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getExpirationStyle`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getExpirationStyle, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setExpirationStyle
+/* std::int32_t */ void
+setExpirationStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                   const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setExpirationStyle`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setExpirationStyle,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getSettlementStyle
+/* const char* */ std::string
+getSettlementStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getSettlementStyle`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getSettlementStyle, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setSettlementStyle
+/* std::int32_t */ void
+setSettlementStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                   const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setSettlementStyle`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setSettlementStyle,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getPriceIncrements
+/* const char* */ std::string
+getPriceIncrements(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getPriceIncrements`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getPriceIncrements, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setPriceIncrements
+/* std::int32_t */ void
+setPriceIncrements(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                   const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setPriceIncrements`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setPriceIncrements,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getTradingHours
+/* const char* */ std::string
+getTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getTradingHours`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getTradingHours, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setTradingHours
+/* std::int32_t */ void setTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                        const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setTradingHours`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setTradingHours,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getField
+/* const char* */ std::string getField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                       const StringLikeWrapper &name) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getField`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getField, static_cast<dxfg_instrument_profile_t *>(ip.get()), name.c_str()));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setField
+/* std::int32_t */ void setField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                 const StringLikeWrapper &name, const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setField`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setField,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), name.c_str(), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getNumericField
+double getNumericField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                       const StringLikeWrapper &name) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getNumericField`. The ip handle is invalid");
+    }
+
+    return runGraalFunctionAndThrowIfMinusInf(dxfg_InstrumentProfile_getNumericField,
+                                              static_cast<dxfg_instrument_profile_t *>(ip.get()), name.c_str());
+}
+
+// dxfg_InstrumentProfile_setNumericField
+/* std::int32_t */ void setNumericField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                        const StringLikeWrapper &name, double value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setNumericField`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setNumericField,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), name.c_str(), value);
+}
+
+// dxfg_InstrumentProfile_getDateField
+std::int32_t getDateField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                          const StringLikeWrapper &name) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getDateField`. The ip handle is invalid");
+    }
+
+    return runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_getDateField,
+                                              static_cast<dxfg_instrument_profile_t *>(ip.get()), name.c_str());
+}
+
+// dxfg_InstrumentProfile_setDateField
+/* std::int32_t */ void setDateField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                     const StringLikeWrapper &name, std::int32_t value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setNumericField`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_InstrumentProfile_setNumericField,
+                                       static_cast<dxfg_instrument_profile_t *>(ip.get()), name.c_str(), value);
+}
+
+// dxfg_InstrumentProfile_getNonEmptyCustomFieldNames
+/* dxfg_string_list* */ std::vector<std::string>
+getNonEmptyCustomFieldNames(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument("Unable to execute function `dxfg_InstrumentProfile_getNonEmptyCustomFieldNames`. "
+                                    "The ip handle is invalid");
+    }
+
+    std::vector<std::string> result;
+    auto graalStringList = internal::IsolatedStringList::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getNonEmptyCustomFieldNames, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+
+    const auto size = static_cast<dxfg_string_list *>(graalStringList.get())->size;
+    const auto elements = static_cast<dxfg_string_list *>(graalStringList.get())->elements;
+
+    result.reserve(size);
+
+    for (auto i = 0; i < size; i++) {
+        result.emplace_back(dxfcpp::toString(elements[i]));
+    }
+
+    result.shrink_to_fit();
+
+    return result;
 }
 
 } // namespace isolated::ipf::IsolatedInstrumentProfile

--- a/src/isolated/ipf/IsolatedInstrumentProfile.cpp
+++ b/src/isolated/ipf/IsolatedInstrumentProfile.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2024 Devexperts LLC.
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dxfg_api.h>
+
+#include <dxfeed_graal_cpp_api/isolated/IsolatedCommon.hpp>
+#include <dxfeed_graal_cpp_api/isolated/internal/IsolatedString.hpp>
+#include <dxfeed_graal_cpp_api/isolated/ipf/IsolatedInstrumentProfile.hpp>
+
+DXFCPP_BEGIN_NAMESPACE
+
+namespace isolated::ipf::IsolatedInstrumentProfile {
+}
+
+DXFCPP_END_NAMESPACE

--- a/src/isolated/ipf/IsolatedInstrumentProfile.cpp
+++ b/src/isolated/ipf/IsolatedInstrumentProfile.cpp
@@ -10,6 +10,424 @@
 DXFCPP_BEGIN_NAMESPACE
 
 namespace isolated::ipf::IsolatedInstrumentProfile {
+
+// dxfg_InstrumentProfile_new
+/* dxfg_instrument_profile_t* */ JavaObjectHandle<InstrumentProfile> create() {
+    return JavaObjectHandle<InstrumentProfile>(runGraalFunctionAndThrowIfNullptr(dxfg_InstrumentProfile_new));
 }
+
+// dxfg_InstrumentProfile_new2
+/* dxfg_instrument_profile_t* */ JavaObjectHandle<InstrumentProfile>
+create(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_new2`. The ip handle is invalid");
+    }
+
+    return JavaObjectHandle<InstrumentProfile>(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_new2, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+}
+
+// dxfg_InstrumentProfile_getType
+/* const char* */ std::string getType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getType`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getType, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setType
+/* int32_t */ void setType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                           const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setType`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setType,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getSymbol
+/* const char* */ std::string
+getSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getSymbol`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getSymbol, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setSymbol
+/* std::int32_t */ void setSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                  const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setSymbol`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setSymbol,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getDescription
+/* const char* */ std::string
+getDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getDescription`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getDescription, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setDescription
+/* std::int32_t */ void setDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                       const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setDescription`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setDescription,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getLocalSymbol
+/* const char* */ std::string
+getLocalSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getLocalSymbol`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getLocalSymbol, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setLocalSymbol
+/* std::int32_t */ void setLocalSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                       const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setLocalSymbol`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setLocalSymbol,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getLocalDescription
+/* const char* */ std::string
+getLocalDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getLocalDescription`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getLocalDescription, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setLocalDescription
+/* std::int32_t */ void
+setLocalDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                    const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setLocalDescription`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setLocalDescription,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getCountry
+/* const char* */ std::string
+getCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getCountry`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getCountry, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setCountry
+/* std::int32_t */ void setCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                   const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setCountry`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setCountry,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getOPOL
+/* const char* */ std::string getOPOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getOPOL`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getOPOL, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setOPOL
+/* std::int32_t */ void setOPOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setOPOL`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setOPOL,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getExchangeData
+/* const char* */ std::string
+getExchangeData(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getExchangeData`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getExchangeData, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setExchangeData
+/* std::int32_t */ void setExchangeData(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                        const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setExchangeData`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setExchangeData,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getExchanges
+/* const char* */ std::string
+getExchanges(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getExchanges`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getExchanges, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setExchanges
+/* std::int32_t */ void setExchanges(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                     const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setExchanges`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setExchanges,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getCurrency
+/* const char* */ std::string
+getCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getCurrency`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getCurrency, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setCurrency
+/* std::int32_t */ void setCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                    const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setCurrency`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setCurrency,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getBaseCurrency
+/* const char* */ std::string
+getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getBaseCurrency`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getBaseCurrency, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setBaseCurrency
+/* std::int32_t */ void setBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                        const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setBaseCurrency`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setBaseCurrency,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getCFI
+/* const char* */ std::string getCFI(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getCFI`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getCFI, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setCFI
+/* std::int32_t */ void setCFI(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                               const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setCFI`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setCFI,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getISIN
+/* const char* */ std::string getISIN(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getISIN`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getISIN, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setISIN
+/* std::int32_t */ void setISIN(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setISIN`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setISIN,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getSEDOL
+/* const char* */ std::string getSEDOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getSEDOL`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getSEDOL, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setSEDOL
+/* std::int32_t */ void setSEDOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                 const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setSEDOL`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setSEDOL,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+// dxfg_InstrumentProfile_getCUSIP
+/* const char* */ std::string getCUSIP(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_getCUSIP`. The ip handle is invalid");
+    }
+
+    const auto string = internal::IsolatedString::toUnique(runGraalFunctionAndThrowIfNullptr(
+        dxfg_InstrumentProfile_getCUSIP, static_cast<dxfg_instrument_profile_t *>(ip.get())));
+    auto result = dxfcpp::toString(string.get());
+
+    return result;
+}
+
+// dxfg_InstrumentProfile_setCUSIP
+/* std::int32_t */ void setCUSIP(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
+                                 const StringLikeWrapper &value) {
+    if (!ip) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_InstrumentProfile_setCUSIP`. The ip handle is invalid");
+    }
+
+    runGraalFunctionAndThrowIfLessThanZero(dxfg_InstrumentProfile_setCUSIP,
+                                           static_cast<dxfg_instrument_profile_t *>(ip.get()), value.c_str());
+}
+
+} // namespace isolated::ipf::IsolatedInstrumentProfile
 
 DXFCPP_END_NAMESPACE

--- a/src/isolated/ipf/IsolatedInstrumentProfile.cpp
+++ b/src/isolated/ipf/IsolatedInstrumentProfile.cpp
@@ -938,4 +938,31 @@ getNonEmptyCustomFieldNames(/* dxfg_instrument_profile_t* */ const JavaObjectHan
 
 } // namespace isolated::ipf::IsolatedInstrumentProfile
 
+namespace isolated::ipf::IsolatedInstrumentProfileList {
+void release(/* dxfg_instrument_profile_list * */ void *list) {
+    if (!list) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_CList_InstrumentProfile_wrapper_release`. The list is nullptr");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_CList_InstrumentProfile_release,
+                                       static_cast<dxfg_instrument_profile_list *>(list));
+}
+
+void releaseWrapper(/* dxfg_instrument_profile_list * */ void *list) {
+    if (!list) {
+        throw std::invalid_argument(
+            "Unable to execute function `dxfg_CList_InstrumentProfile_wrapper_release`. The list is nullptr");
+    }
+
+    runGraalFunctionAndThrowIfMinusOne(dxfg_CList_InstrumentProfile_wrapper_release,
+                                       static_cast<dxfg_instrument_profile_list *>(list));
+}
+
+std::unique_ptr<void, decltype(&releaseWrapper)> toUniqueWrapper(/* dxfg_instrument_profile_list * */ void *list) {
+    return {list, releaseWrapper};
+}
+
+} // namespace isolated::ipf::IsolatedInstrumentProfileList
+
 DXFCPP_END_NAMESPACE

--- a/src/schedule/Day.cpp
+++ b/src/schedule/Day.cpp
@@ -253,7 +253,7 @@ std::size_t Day::getHashCode() const noexcept {
     return isolated::schedule::Day::getHashCode(handle_.get());
 }
 
-std::string Day::toString() const noexcept {
+std::string Day::toString() const {
     if (!handle_) {
         return dxfcpp::String::EMPTY;
     }

--- a/src/schedule/Schedule.cpp
+++ b/src/schedule/Schedule.cpp
@@ -13,8 +13,7 @@ Schedule::Schedule(void *handle) noexcept : handle_(handle) {
 
 Schedule::Ptr Schedule::create(void *handle) {
     if (!handle) {
-        throw std::invalid_argument(
-            "Unable to create a Schedule object. The handle is nullptr");
+        throw std::invalid_argument("Unable to create a Schedule object. The handle is nullptr");
     }
 
     return std::shared_ptr<Schedule>(new Schedule(handle));
@@ -25,9 +24,7 @@ Schedule::Ptr Schedule::getInstance(std::shared_ptr<InstrumentProfile> profile) 
         throw std::invalid_argument("The profile is nullptr");
     }
 
-    auto graalProfile = profile->toGraal();
-    auto schedule = create(isolated::schedule::Schedule::getInstance(graalProfile));
-    InstrumentProfile::freeGraal(graalProfile);
+    auto schedule = create(isolated::schedule::Schedule::getInstance(profile->handle_.get()));
 
     return schedule;
 }
@@ -41,9 +38,7 @@ Schedule::Ptr Schedule::getInstance(std::shared_ptr<InstrumentProfile> profile, 
         throw std::invalid_argument("The profile is nullptr");
     }
 
-    auto graalProfile = profile->toGraal();
-    auto schedule = create(isolated::schedule::Schedule::getInstance(graalProfile, venue));
-    InstrumentProfile::freeGraal(graalProfile);
+    auto schedule = create(isolated::schedule::Schedule::getInstance(profile->handle_.get(), venue));
 
     return schedule;
 }
@@ -53,9 +48,7 @@ std::vector<std::string> Schedule::getTradingVenues(std::shared_ptr<InstrumentPr
         throw std::invalid_argument("The profile is nullptr");
     }
 
-    auto graalProfile = profile->toGraal();
-    auto result = isolated::schedule::Schedule::getTradingVenues(graalProfile);
-    InstrumentProfile::freeGraal(graalProfile);
+    auto result = isolated::schedule::Schedule::getTradingVenues(profile->handle_.get());
 
     return result;
 }
@@ -109,7 +102,7 @@ Session::Ptr Schedule::getNearestSessionByTime(std::int64_t time, const SessionF
         isolated::schedule::Schedule::getNearestSessionByTime(handle_.get(), time, filter.handle_.get()));
 }
 
-Session::Ptr Schedule::findNearestSessionByTime(std::int64_t time, const SessionFilter& filter) const noexcept {
+Session::Ptr Schedule::findNearestSessionByTime(std::int64_t time, const SessionFilter &filter) const noexcept {
     if (!handle_ || !filter.handle_) {
         return {};
     }

--- a/src/schedule/Session.cpp
+++ b/src/schedule/Session.cpp
@@ -139,7 +139,7 @@ std::size_t Session::getHashCode() const noexcept {
     return isolated::schedule::Session::getHashCode(handle_.get());
 }
 
-std::string Session::toString() const noexcept {
+std::string Session::toString() const {
     if (!handle_) {
         return dxfcpp::String::EMPTY;
     }


### PR DESCRIPTION
It is required to refactor `InstrumenProfile` to allow custom fields to be retrieved from it. 

What must be done:
* The API should be migrated to Graal SDK v1.1.22+
* `InstrumentProfile` should be represented as a `JavaObjectHandle<InstrumentProfile>`.
* All methods that accept/return this class must return its handle.
* All methods in `InstrumentProfile` should be referred to `IsolatedInstrumentProfile`. 

