### PR TITLE
[MDAPI-113]  [C++][Tools] Tools should report invalid event type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ set(dxFeedGraalCxxApi_InternalUtilsDebug_Sources
 
 set(dxFeedGraalCxxApi_Exceptions_Sources
         src/exceptions/RuntimeException.cpp
+        src/exceptions/InvalidArgumentException.cpp
         src/exceptions/GraalException.cpp
         src/exceptions/JavaException.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ set(dxFeedGraalCxxApi_InternalUtilsDebug_Sources
 )
 
 set(dxFeedGraalCxxApi_Exceptions_Sources
+        src/exceptions/RuntimeException.cpp
         src/exceptions/GraalException.cpp
         src/exceptions/JavaException.cpp
 )

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,8 @@
+* **\[MDAPI-113]\[C++]\[Tools]** Tools should report invalid event type
+  *  Added classes: `RuntimeException`, `InvalidArgumentException`
+  *  `InvalidArgumentException`, `GraalException`, `JavaException` are now descendants of the `RuntimeException` class, which can collect stacktrace.
+  *  Now an `InvalidArgumentException` exception is thrown instead of the `std::invalid_argument` exception. 
+  *  `Tools` now reports incorrect event types specified by the user.
 * **\[MDAPI-80]\[C++]\[IPF]** Implement custom fields in InstrumentProfile
   * The API was migrated to Graal SDK v1.1.22
   * Added methods:

--- a/include/dxfeed_graal_cpp_api/api.hpp
+++ b/include/dxfeed_graal_cpp_api/api.hpp
@@ -52,6 +52,7 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251 4996)
 
 #include "isolated/Isolated.hpp"
 
+#include "exceptions/RuntimeException.hpp"
 #include "exceptions/JavaException.hpp"
 #include "exceptions/GraalException.hpp"
 

--- a/include/dxfeed_graal_cpp_api/api.hpp
+++ b/include/dxfeed_graal_cpp_api/api.hpp
@@ -53,6 +53,7 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251 4996)
 #include "isolated/Isolated.hpp"
 
 #include "exceptions/RuntimeException.hpp"
+#include "exceptions/InvalidArgumentException.hpp"
 #include "exceptions/JavaException.hpp"
 #include "exceptions/GraalException.hpp"
 

--- a/include/dxfeed_graal_cpp_api/api/DXEndpoint.hpp
+++ b/include/dxfeed_graal_cpp_api/api/DXEndpoint.hpp
@@ -178,7 +178,7 @@ struct OnDemandService;
  *
  * Some methods that are not marked `noexcept` may throw exceptions:
  *
- * @throws std::invalid_argument if handle is invalid.
+ * @throws InvalidArgumentException if handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend
  * @throws GraalException if something happened with the GraalVM
  */
@@ -481,7 +481,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
 
     // Throws:
     //   - std::bad_alloc if it was not possible to allocate the required amount of memory
-    //   - std::invalid_argument if endpointHandle is nullptr
+    //   - InvalidArgumentException if endpointHandle is nullptr
     //   - JavaException if something happened with the dxFeed API backend
     //   - GraalException if something happened with the GraalVM
     static std::shared_ptr<DXEndpoint> create(void *endpointHandle, Role role,
@@ -509,7 +509,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      * @ref DXEndpoint::getInstance(Role) "getInstance"(@ref DXEndpoint "DXEndpoint"::@ref DXEndpoint::Role "Role"::@ref
      * DXEndpoint.Role::FEED "FEED").
      * @see DXEndpoint::getInstance(Role)
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -533,7 +533,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * @param role The role of DXEndpoint instance
      * @return The DXEndpoint instance
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -546,7 +546,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      * Use Builder::build() to build an instance of DXEndpoint when all configuration properties were set.
      *
      * @return the created endpoint builder.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -559,7 +559,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      * @ref DXEndpoint::newBuilder() "newBuilder()"->@ref Builder::build() "build()"
      *
      * @return the created endpoint.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -573,7 +573,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * @param role the role.
      * @return the created endpoint.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -594,7 +594,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      * @return the state.
      *
      * @see DXEndpoint
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -602,7 +602,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
 
     /**
      * @return `true` if the endpoint is closed
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -658,7 +658,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      * @param user The user name.
      *
      * @return this DXEndpoint.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -672,7 +672,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      * @param password The password.
      *
      * @return this DXEndpoint.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -706,7 +706,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      * @param address The data source address.
      * @return this DXEndpoint.
      *
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException if something happened with the dxFeed API backend or if address string is malformed.
      * @throws GraalException
      */
@@ -728,7 +728,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * [Javadoc.](https://docs.dxfeed.com/dxfeed/api/com/dxfeed/api/DXEndpoint.html#reconnect--)
      *
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -744,7 +744,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * [Javadoc.](https://docs.dxfeed.com/dxfeed/api/com/dxfeed/api/DXEndpoint.html#disconnect--)
      *
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -760,7 +760,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * [Javadoc.](https://docs.dxfeed.com/dxfeed/api/com/dxfeed/api/DXEndpoint.html#disconnectAndClear--)
      *
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -775,7 +775,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * [Javadoc.](https://docs.dxfeed.com/dxfeed/api/com/dxfeed/api/DXEndpoint.html#close--)
      *
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -792,7 +792,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * [Javadoc.](https://docs.dxfeed.com/dxfeed/api/com/dxfeed/api/DXEndpoint.html#awaitNotConnected--)
      *
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -805,7 +805,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * [Javadoc.](https://docs.dxfeed.com/dxfeed/api/com/dxfeed/api/DXEndpoint.html#awaitProcessed--)
      *
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -822,7 +822,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * [Javadoc.](https://docs.dxfeed.com/dxfeed/api/com/dxfeed/api/DXEndpoint.html#closeAndAwaitTermination--)
      *
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -833,7 +833,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
 
     /**
      * @return The feed that is associated with this endpoint.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -841,7 +841,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
 
     /**
      * @return The publisher that is associated with this endpoint.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      * @throws JavaException
      * @throws GraalException
      */
@@ -852,7 +852,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
      *
      * Some methods that are not marked `noexcept` may throw exceptions:
      *
-     * @throws std::invalid_argument if handle is invalid.
+     * @throws InvalidArgumentException if handle is invalid.
      * @throws JavaException if something happened with the dxFeed API backend
      * @throws GraalException if something happened with the GraalVM
      */
@@ -880,7 +880,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
          * or "dxpublisher.properties" for the Role::PUBLISHER role.
          *
          * Non thread-safe.
-         * @throws std::invalid_argument
+         * @throws InvalidArgumentException
          * @throws JavaException
          * @throws GraalException
          */
@@ -900,7 +900,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
          * @param name The endpoint's name
          *
          * @return `this` endpoint builder.
-         * @throws std::invalid_argument
+         * @throws InvalidArgumentException
          * @throws JavaException
          * @throws GraalException
          */
@@ -913,7 +913,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
          * @param role The endpoint's role
          *
          * @return `this` endpoint builder.
-         * @throws std::invalid_argument
+         * @throws InvalidArgumentException
          * @throws JavaException
          * @throws GraalException
          */
@@ -927,7 +927,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
          * @return `this` endpoint builder.
          *
          * @see ::supportsProperty(const std::string&)
-         * @throws std::invalid_argument
+         * @throws InvalidArgumentException
          * @throws JavaException
          * @throws GraalException
          */
@@ -941,7 +941,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
          * @return `this` endpoint builder.
          *
          * @see ::withProperty(const std::string&, const std::string&)
-         * @throws std::invalid_argument
+         * @throws InvalidArgumentException
          * @throws JavaException
          * @throws GraalException
          */
@@ -965,7 +965,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
          * @return `true` if the corresponding property key is supported.
          *
          * @see ::withProperty(const std::string&, const std::string&)
-         * @throws std::invalid_argument
+         * @throws InvalidArgumentException
          * @throws JavaException
          * @throws GraalException
          */
@@ -975,7 +975,7 @@ struct DXFCPP_EXPORT DXEndpoint : public RequireMakeShared<DXEndpoint> {
          * Builds DXEndpoint instance.
          *
          * @return the created endpoint.
-         * @throws std::invalid_argument
+         * @throws InvalidArgumentException
          * @throws JavaException
          * @throws GraalException
          */

--- a/include/dxfeed_graal_cpp_api/api/osub/IndexedEventSubscriptionSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/api/osub/IndexedEventSubscriptionSymbol.hpp
@@ -56,6 +56,7 @@ class DXFCPP_EXPORT IndexedEventSubscriptionSymbol {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -65,7 +66,7 @@ class DXFCPP_EXPORT IndexedEventSubscriptionSymbol {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static IndexedEventSubscriptionSymbol fromGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/api/osub/TimeSeriesSubscriptionSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/api/osub/TimeSeriesSubscriptionSymbol.hpp
@@ -84,6 +84,7 @@ class DXFCPP_EXPORT TimeSeriesSubscriptionSymbol final : public IndexedEventSubs
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -93,7 +94,7 @@ class DXFCPP_EXPORT TimeSeriesSubscriptionSymbol final : public IndexedEventSubs
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static TimeSeriesSubscriptionSymbol fromGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/api/osub/WildcardSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/api/osub/WildcardSymbol.hpp
@@ -73,6 +73,7 @@ struct DXFCPP_EXPORT WildcardSymbol final {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -81,7 +82,7 @@ struct DXFCPP_EXPORT WildcardSymbol final {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static const WildcardSymbol &fromGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/IndexedEventSource.hpp
+++ b/include/dxfeed_graal_cpp_api/event/IndexedEventSource.hpp
@@ -41,6 +41,7 @@ class DXFCPP_EXPORT IndexedEventSource {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -49,7 +50,7 @@ class DXFCPP_EXPORT IndexedEventSource {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static IndexedEventSource fromGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/candle/Candle.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/Candle.hpp
@@ -14,6 +14,9 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
 #include <utility>
 
 #include "../../internal/Common.hpp"
+
+#include "../../exceptions/InvalidArgumentException.hpp"
+
 #include "../EventType.hpp"
 #include "../EventTypeEnum.hpp"
 #include "../IndexedEventSource.hpp"
@@ -126,7 +129,7 @@ class DXFCPP_EXPORT Candle final : public EventTypeWithSymbol<CandleSymbol>,
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -143,6 +146,7 @@ class DXFCPP_EXPORT Candle final : public EventTypeWithSymbol<CandleSymbol>,
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -343,13 +347,13 @@ class DXFCPP_EXPORT Candle final : public EventTypeWithSymbol<CandleSymbol>,
      *
      * @param sequence the sequence.
      * @see Candle::getSequence()
-     * @throws std::invalid_argument if sequence is below zero or above ::MAX_SEQUENCE.
+     * @throws InvalidArgumentException if sequence is below zero or above ::MAX_SEQUENCE.
      */
     void setSequence(std::int32_t sequence) {
         assert(sequence >= 0 && static_cast<std::uint32_t>(sequence) <= MAX_SEQUENCE);
 
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid value for argument `sequence`: " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid value for argument `sequence`: " + std::to_string(sequence));
         }
 
         data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/event/candle/CandleAlignment.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandleAlignment.hpp
@@ -8,6 +8,7 @@
 DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
 
 #include "../../internal/utils/StringUtils.hpp"
+#include "../../exceptions/InvalidArgumentException.hpp"
 #include "../market/MarketEventSymbols.hpp"
 #include "CandleSymbolAttribute.hpp"
 
@@ -101,7 +102,7 @@ struct DXFCPP_EXPORT CandleAlignment : public CandleSymbolAttribute {
      *
      * @param s The string representation of candle alignment.
      * @return The candle alignment (reference)
-     * @throws std::invalid_argument if the string representation is invalid.
+     * @throws InvalidArgumentException if the string representation is invalid.
      */
     static std::reference_wrapper<const CandleAlignment> parse(const dxfcpp::StringLikeWrapper &s) {
         auto found = BY_STRING.find(s);
@@ -118,7 +119,7 @@ struct DXFCPP_EXPORT CandleAlignment : public CandleSymbolAttribute {
             }
         }
 
-        throw std::invalid_argument("Unknown candle alignment: " + s);
+        throw InvalidArgumentException("Unknown candle alignment: " + s);
     }
 
     /**
@@ -152,7 +153,7 @@ struct DXFCPP_EXPORT CandleAlignment : public CandleSymbolAttribute {
         try {
             auto other = parse(a.value());
 
-            if (other == DEFAULT) {
+            if (other.get() == DEFAULT) {
                 return MarketEventSymbols::removeAttributeStringByKey(symbol, ATTRIBUTE_KEY);
             }
 
@@ -160,6 +161,8 @@ struct DXFCPP_EXPORT CandleAlignment : public CandleSymbolAttribute {
                 return MarketEventSymbols::changeAttributeStringByKey(symbol, ATTRIBUTE_KEY, other.get().toString());
             }
 
+            return symbol;
+        } catch (const InvalidArgumentException &) {
             return symbol;
         } catch (const std::invalid_argument &) {
             return symbol;

--- a/include/dxfeed_graal_cpp_api/event/candle/CandlePeriod.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandlePeriod.hpp
@@ -235,6 +235,8 @@ struct DXFCPP_EXPORT CandlePeriod : public CandleSymbolAttribute {
             }
 
             return symbol;
+        } catch (const InvalidArgumentException &) {
+            return symbol;
         } catch (const std::invalid_argument &) {
             return symbol;
         }

--- a/include/dxfeed_graal_cpp_api/event/candle/CandlePriceLevel.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandlePriceLevel.hpp
@@ -117,10 +117,11 @@ struct DXFCPP_EXPORT CandlePriceLevel : public CandleSymbolAttribute {
      *
      * @param value candle price level value.
      * @return candle price level with the given value and type.
+     * @throws InvalidArgumentException if value is incorrect
      */
     static CandlePriceLevel valueOf(double value) {
         if (std::isinf(value) || (value == 0.0 && std::signbit(value))) {
-            throw std::invalid_argument("Incorrect candle price level: " + dxfcpp::toString(value));
+            throw InvalidArgumentException("Incorrect candle price level: " + dxfcpp::toString(value));
         }
 
         return std::isnan(value) ? DEFAULT : CandlePriceLevel(value);
@@ -164,6 +165,8 @@ struct DXFCPP_EXPORT CandlePriceLevel : public CandleSymbolAttribute {
                 return MarketEventSymbols::changeAttributeStringByKey(symbol, ATTRIBUTE_KEY, other.toString());
             }
 
+            return symbol;
+        } catch (const InvalidArgumentException &) {
             return symbol;
         } catch (const std::invalid_argument &) {
             return symbol;

--- a/include/dxfeed_graal_cpp_api/event/candle/CandleSession.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandleSession.hpp
@@ -113,14 +113,11 @@ struct DXFCPP_EXPORT CandleSession : public CandleSymbolAttribute {
      *
      * @param s The string representation of candle session attribute.
      * @return The candle session attribute (reference).
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException if argument is empty or invalid
      */
     static std::reference_wrapper<const CandleSession> parse(const dxfcpp::StringLikeWrapper &s) {
-        auto sw = s.operator std::string_view();
-        auto n = sw.length();
-
-        if (n == 0) {
-            throw std::invalid_argument("Missing candle session");
+        if (s.empty()) {
+            throw InvalidArgumentException("Missing candle session");
         }
 
         auto found = BY_STRING.find(s);
@@ -132,12 +129,12 @@ struct DXFCPP_EXPORT CandleSession : public CandleSymbolAttribute {
         for (const auto &sessionRef : VALUES) {
             const auto &sessionStr = sessionRef.get().toString();
 
-            if (sessionStr.length() >= n && iEquals(sessionStr.substr(0, n), s)) {
+            if (sessionStr.length() >= s.length() && iEquals(sessionStr.substr(0, s.length()), s)) {
                 return sessionRef;
             }
         }
 
-        throw std::invalid_argument("Unknown candle session: " + s);
+        throw InvalidArgumentException("Unknown candle session: " + s);
     }
 
     /**
@@ -169,7 +166,7 @@ struct DXFCPP_EXPORT CandleSession : public CandleSymbolAttribute {
         try {
             auto other = parse(a.value());
 
-            if (other == DEFAULT) {
+            if (other.get() == DEFAULT) {
                 return MarketEventSymbols::removeAttributeStringByKey(symbol, ATTRIBUTE_KEY);
             }
 
@@ -177,6 +174,8 @@ struct DXFCPP_EXPORT CandleSession : public CandleSymbolAttribute {
                 return MarketEventSymbols::changeAttributeStringByKey(symbol, ATTRIBUTE_KEY, other.get().toString());
             }
 
+            return symbol;
+        } catch (const InvalidArgumentException &) {
             return symbol;
         } catch (const std::invalid_argument &) {
             return symbol;

--- a/include/dxfeed_graal_cpp_api/event/candle/CandleSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandleSymbol.hpp
@@ -273,6 +273,7 @@ struct DXFCPP_EXPORT CandleSymbol {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -281,7 +282,7 @@ struct DXFCPP_EXPORT CandleSymbol {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static CandleSymbol fromGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/candle/CandleType.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandleType.hpp
@@ -158,7 +158,7 @@ struct DXFCPP_EXPORT CandleType {
      * distinguish it from CandleType::MINUTE that is represented as `"m"`.
      *
      * @return string representation of this candle price type.
-     * @throws std::invalid_argument if the string representation is invalid.
+     * @throws InvalidArgumentException if the string representation is invalid.
      */
     const std::string &toString() const & noexcept {
         return string_;
@@ -171,16 +171,14 @@ struct DXFCPP_EXPORT CandleType {
      *
      * @param s The string representation of candle type.
      * @return A candle type.
+     * @throws InvalidArgumentException if argument is empty or invalid
      */
     static std::reference_wrapper<const CandleType> parse(const dxfcpp::StringLikeWrapper &s) {
-        auto sw = s.operator std::string_view();
-        auto n = sw.length();
-
-        if (n == 0) {
-            throw std::invalid_argument("Missing candle type");
+        if (s.empty()) {
+            throw InvalidArgumentException("Missing candle type");
         }
 
-        auto result = BY_STRING.find(sw);
+        auto result = BY_STRING.find(s);
 
         if (result != BY_STRING.end()) {
             return result->second;
@@ -190,17 +188,17 @@ struct DXFCPP_EXPORT CandleType {
             const auto &name = typeRef.get().getName();
 
             // Tick|TICK|tick, Minute|MINUTE|minute, Second|SECOND|second, etc
-            if (name.length() >= n && iEquals(name.substr(0, n), sw)) {
+            if (name.length() >= s.length() && iEquals(name.substr(0, s.length()), s)) {
                 return typeRef;
             }
 
             // Ticks, Minutes, Seconds, etc
-            if (sw.ends_with("s") && iEquals(name, sw.substr(0, n - 1))) {
+            if (s.ends_with("s") && iEquals(name, s.substr(0, s.length() - 1))) {
                 return typeRef;
             }
         }
 
-        throw std::invalid_argument("Unknown candle type: " + s);
+        throw InvalidArgumentException("Unknown candle type: " + s);
     }
 
     bool operator==(const CandleType &candleType) const noexcept {

--- a/include/dxfeed_graal_cpp_api/event/market/AnalyticOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/AnalyticOrder.hpp
@@ -89,7 +89,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -106,6 +106,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/market/OptionSale.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OptionSale.hpp
@@ -107,7 +107,7 @@ class DXFCPP_EXPORT OptionSale final : public MarketEvent, public IndexedEvent {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -124,6 +124,7 @@ class DXFCPP_EXPORT OptionSale final : public MarketEvent, public IndexedEvent {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -409,12 +410,13 @@ class DXFCPP_EXPORT OptionSale final : public MarketEvent, public IndexedEvent {
      *
      * @param sequence the sequence.
      * @see ::getSequence()
+     * @throws InvalidArgumentException
      */
     void setSequence(std::int32_t sequence) {
         assert(sequence >= 0 && static_cast<std::uint32_t>(sequence) <= MAX_SEQUENCE);
 
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid sequence value = " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
         }
 
         data_.timeSequence = orOp(andOp(data_.timeSequence, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/event/market/Order.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Order.hpp
@@ -121,7 +121,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -138,6 +138,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/market/OrderBase.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OrderBase.hpp
@@ -234,10 +234,11 @@ class DXFCPP_EXPORT OrderBase : public MarketEvent, public IndexedEvent {
      * Use OrderBase::setSource() after invocation of this method to set the desired value of source.
      *
      * @param index unique per-symbol index of this order.
+     * @throws InvalidArgumentException
      */
     void setIndex(std::int64_t index) override {
         if (index < 0) {
-            throw std::invalid_argument("Negative index: " + std::to_string(index));
+            throw InvalidArgumentException("Negative index: " + std::to_string(index));
         }
 
         orderBaseData_.index = index;
@@ -333,10 +334,11 @@ class DXFCPP_EXPORT OrderBase : public MarketEvent, public IndexedEvent {
      * @param sequence the sequence.
      *
      * @see OrderBase::getSequence()
+     * @throws InvalidArgumentException
      */
     void setSequence(std::int32_t sequence) {
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid sequence value = " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
         }
 
         orderBaseData_.timeSequence = orOp(andOp(orderBaseData_.timeSequence, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/event/market/OrderSource.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OrderSource.hpp
@@ -71,7 +71,7 @@ class DXFCPP_EXPORT OrderSource final : public IndexedEventSource {
         auto n = name.length();
 
         if (n == 0 || n > 4) {
-            throw std::invalid_argument("Source name must contain from 1 to 4 characters");
+            throw InvalidArgumentException("Source name must contain from 1 to 4 characters");
         }
 
         for (auto c : name) {
@@ -87,12 +87,12 @@ class DXFCPP_EXPORT OrderSource final : public IndexedEventSource {
             return;
         }
 
-        throw std::invalid_argument("Source name must contain only alphanumeric characters");
+        throw InvalidArgumentException("Source name must contain only alphanumeric characters");
     }
 
     static std::string decodeName(std::int32_t id) {
         if (id == 0) {
-            throw std::invalid_argument("Source name must contain from 1 to 4 characters");
+            throw InvalidArgumentException("Source name must contain from 1 to 4 characters");
         }
 
         std::string name(4, '\0');
@@ -130,7 +130,7 @@ class DXFCPP_EXPORT OrderSource final : public IndexedEventSource {
             return PUB_SPREAD_ORDER;
         }
 
-        throw std::invalid_argument("Invalid order event type: " + eventType.getName());
+        throw InvalidArgumentException("Invalid order event type: " + eventType.getName());
     }
 
     /**

--- a/include/dxfeed_graal_cpp_api/event/market/OtcMarketsOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OtcMarketsOrder.hpp
@@ -156,7 +156,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -173,6 +173,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/market/Profile.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Profile.hpp
@@ -87,7 +87,7 @@ class DXFCPP_EXPORT Profile final : public MarketEvent, public LastingEvent {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -104,6 +104,7 @@ class DXFCPP_EXPORT Profile final : public MarketEvent, public LastingEvent {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/market/Quote.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Quote.hpp
@@ -80,7 +80,7 @@ class DXFCPP_EXPORT Quote final : public MarketEvent, public LastingEvent {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -97,6 +97,7 @@ class DXFCPP_EXPORT Quote final : public MarketEvent, public LastingEvent {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -153,12 +154,13 @@ class DXFCPP_EXPORT Quote final : public MarketEvent, public LastingEvent {
      * @param sequence The sequence.
      *
      * @see Quote::getSequence()
+     * @throws InvalidArgumentException
      */
     void setSequence(std::int32_t sequence) {
         assert(sequence >= 0 && static_cast<std::uint32_t>(sequence) <= MAX_SEQUENCE);
 
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid sequence value = " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
         }
 
         data_.timeMillisSequence = orOp(andOp(data_.timeMillisSequence, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/event/market/SpreadOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/SpreadOrder.hpp
@@ -120,7 +120,7 @@ class DXFCPP_EXPORT SpreadOrder : public OrderBase {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -137,6 +137,7 @@ class DXFCPP_EXPORT SpreadOrder : public OrderBase {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/market/Summary.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Summary.hpp
@@ -78,7 +78,7 @@ class DXFCPP_EXPORT Summary final : public MarketEvent, public LastingEvent {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -95,6 +95,7 @@ class DXFCPP_EXPORT Summary final : public MarketEvent, public LastingEvent {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/market/TimeAndSale.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/TimeAndSale.hpp
@@ -135,7 +135,7 @@ class DXFCPP_EXPORT TimeAndSale final : public MarketEvent, public TimeSeriesEve
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -152,6 +152,7 @@ class DXFCPP_EXPORT TimeAndSale final : public MarketEvent, public TimeSeriesEve
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -292,12 +293,13 @@ class DXFCPP_EXPORT TimeAndSale final : public MarketEvent, public TimeSeriesEve
      *
      * @param sequence the sequence.
      * @see ::getSequence()
+     * @throws InvalidArgumentException
      */
     void setSequence(std::int32_t sequence) {
         assert(sequence >= 0 && static_cast<std::uint32_t>(sequence) <= MAX_SEQUENCE);
 
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid sequence value = " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
         }
 
         data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/event/market/Trade.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Trade.hpp
@@ -92,7 +92,7 @@ class DXFCPP_EXPORT Trade final : public TradeBase {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -109,6 +109,7 @@ class DXFCPP_EXPORT Trade final : public TradeBase {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/market/TradeBase.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/TradeBase.hpp
@@ -192,12 +192,13 @@ class DXFCPP_EXPORT TradeBase : public MarketEvent, public LastingEvent {
      *
      * @param sequence the sequence.
      * @see TradeBase::getSequence()
+     * @throws InvalidArgumentException
      */
     void setSequence(std::int32_t sequence) {
         assert(sequence >= 0 && static_cast<std::uint32_t>(sequence) <= MAX_SEQUENCE);
 
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid sequence value = " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
         }
 
         tradeBaseData_.timeSequence = orOp(andOp(tradeBaseData_.timeSequence, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/event/market/TradeETH.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/TradeETH.hpp
@@ -117,7 +117,7 @@ class DXFCPP_EXPORT TradeETH final : public TradeBase {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -134,6 +134,7 @@ class DXFCPP_EXPORT TradeETH final : public TradeBase {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/misc/Message.hpp
+++ b/include/dxfeed_graal_cpp_api/event/misc/Message.hpp
@@ -56,7 +56,7 @@ class DXFCPP_EXPORT Message : public EventTypeWithSymbol<std::string> {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -73,6 +73,7 @@ class DXFCPP_EXPORT Message : public EventTypeWithSymbol<std::string> {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/event/option/Greeks.hpp
+++ b/include/dxfeed_graal_cpp_api/event/option/Greeks.hpp
@@ -95,7 +95,7 @@ class DXFCPP_EXPORT Greeks final : public MarketEvent, public TimeSeriesEvent, p
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -119,6 +119,7 @@ class DXFCPP_EXPORT Greeks final : public MarketEvent, public TimeSeriesEvent, p
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -219,12 +220,13 @@ class DXFCPP_EXPORT Greeks final : public MarketEvent, public TimeSeriesEvent, p
      * Changes @ref ::getSequence() "sequence number" of this event.
      * @param sequence the sequence.
      * @see ::getSequence()
+     * @throws InvalidArgumentException
      */
     void setSequence(std::int32_t sequence) {
         assert(sequence >= 0 && static_cast<std::uint32_t>(sequence) <= MAX_SEQUENCE);
 
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid value for argument `sequence`: " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid value for argument `sequence`: " + std::to_string(sequence));
         }
 
         data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/event/option/Series.hpp
+++ b/include/dxfeed_graal_cpp_api/event/option/Series.hpp
@@ -110,7 +110,7 @@ class DXFCPP_EXPORT Series final : public MarketEvent, public IndexedEvent {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -127,6 +127,7 @@ class DXFCPP_EXPORT Series final : public MarketEvent, public IndexedEvent {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -324,12 +325,13 @@ class DXFCPP_EXPORT Series final : public MarketEvent, public IndexedEvent {
      *
      * @param sequence the sequence.
      * @see Series::getSequence()
+     * @throws InvalidArgumentException
      */
     void setSequence(std::int32_t sequence) {
         assert(sequence >= 0 && static_cast<std::uint32_t>(sequence) <= MAX_SEQUENCE);
 
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid value for argument `sequence`: " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid value for argument `sequence`: " + std::to_string(sequence));
         }
 
         data_.timeSequence = orOp(andOp(data_.timeSequence, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/event/option/TheoPrice.hpp
+++ b/include/dxfeed_graal_cpp_api/event/option/TheoPrice.hpp
@@ -109,7 +109,7 @@ class DXFCPP_EXPORT TheoPrice final : public MarketEvent, public TimeSeriesEvent
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -126,6 +126,7 @@ class DXFCPP_EXPORT TheoPrice final : public MarketEvent, public TimeSeriesEvent
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -226,12 +227,13 @@ class DXFCPP_EXPORT TheoPrice final : public MarketEvent, public TimeSeriesEvent
      * Changes @ref ::getSequence() "sequence number" of this event.
      * @param sequence the sequence.
      * @see ::getSequence()
+     * @throws InvalidArgumentException
      */
     void setSequence(std::int32_t sequence) {
         assert(sequence >= 0 && static_cast<std::uint32_t>(sequence) <= MAX_SEQUENCE);
 
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid value for argument `sequence`: " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid value for argument `sequence`: " + std::to_string(sequence));
         }
 
         data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/event/option/Underlying.hpp
+++ b/include/dxfeed_graal_cpp_api/event/option/Underlying.hpp
@@ -105,7 +105,7 @@ class DXFCPP_EXPORT Underlying final : public MarketEvent, public TimeSeriesEven
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static Ptr fromGraal(void *graalNative);
 
@@ -122,6 +122,7 @@ class DXFCPP_EXPORT Underlying final : public MarketEvent, public TimeSeriesEven
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -222,12 +223,13 @@ class DXFCPP_EXPORT Underlying final : public MarketEvent, public TimeSeriesEven
      * Changes @ref ::getSequence() "sequence number" of this event.
      * @param sequence the sequence.
      * @see ::getSequence()
+     * @throws InvalidArgumentException
      */
     void setSequence(std::int32_t sequence) {
         assert(sequence >= 0 && static_cast<std::uint32_t>(sequence) <= MAX_SEQUENCE);
 
         if (sequence < 0 || static_cast<std::uint32_t>(sequence) > MAX_SEQUENCE) {
-            throw std::invalid_argument("Invalid value for argument `sequence`: " + std::to_string(sequence));
+            throw InvalidArgumentException("Invalid value for argument `sequence`: " + std::to_string(sequence));
         }
 
         data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);

--- a/include/dxfeed_graal_cpp_api/exceptions/GraalException.hpp
+++ b/include/dxfeed_graal_cpp_api/exceptions/GraalException.hpp
@@ -9,6 +9,8 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251 4275)
 
 #include "../internal/CEntryPointErrors.hpp"
 
+#include "RuntimeException.hpp"
+
 #include <stdexcept>
 #include <string>
 
@@ -17,18 +19,13 @@ DXFCPP_BEGIN_NAMESPACE
 /**
  * The wrapper over CEntryPointErrorsEnum, the error code returned by GraalVM.
  */
-struct DXFCPP_EXPORT GraalException : public std::runtime_error {
+struct DXFCPP_EXPORT GraalException : RuntimeException {
     /**
      * Constructs an exception.
      *
      * @param entryPointErrorsEnum The error code returned by GraalVM.
      */
     GraalException(CEntryPointErrorsEnum entryPointErrorsEnum);
-
-    /**
-     * @return dxFeed Graal CXX API stack trace
-     */
-    const std::string& getStackTrace() const&;
 
   private:
     static inline std::string createMessage(CEntryPointErrorsEnum entryPointErrorsEnum) {
@@ -41,8 +38,6 @@ struct DXFCPP_EXPORT GraalException : public std::runtime_error {
 
         return result;
     }
-
-    std::string stackTrace_;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/exceptions/InvalidArgumentException.hpp
+++ b/include/dxfeed_graal_cpp_api/exceptions/InvalidArgumentException.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 Devexperts LLC.
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include "../internal/Conf.hpp"
+
+#include "../internal/Common.hpp"
+#include "RuntimeException.hpp"
+
+DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251 4275)
+
+#include <stdexcept>
+#include <string>
+
+DXFCPP_BEGIN_NAMESPACE
+
+/**
+ * Thrown to indicate that a method has been passed an illegal or inappropriate argument.
+ */
+struct DXFCPP_EXPORT InvalidArgumentException : RuntimeException {
+    explicit InvalidArgumentException(const StringLikeWrapper &message,
+                                      const StringLikeWrapper &additionalStackTrace = "");
+};
+
+DXFCPP_END_NAMESPACE
+
+DXFCXX_DISABLE_MSC_WARNINGS_POP()

--- a/include/dxfeed_graal_cpp_api/exceptions/JavaException.hpp
+++ b/include/dxfeed_graal_cpp_api/exceptions/JavaException.hpp
@@ -5,7 +5,11 @@
 
 #include "../internal/Conf.hpp"
 
+#include "../internal/Common.hpp"
+
 DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251 4275)
+
+#include "RuntimeException.hpp"
 
 #include <limits>
 #include <stdexcept>
@@ -17,7 +21,7 @@ DXFCPP_BEGIN_NAMESPACE
 /**
  * A wrapper over the interceptable Java exceptions thrown by the dxFeed Native Graal SDK
  */
-struct DXFCPP_EXPORT JavaException : public std::runtime_error {
+struct DXFCPP_EXPORT JavaException : RuntimeException {
     /**
      * Creates an exception using Java message, className and stack trace. Also uses current stack trace.
      *
@@ -25,7 +29,8 @@ struct DXFCPP_EXPORT JavaException : public std::runtime_error {
      * @param className Java class name.
      * @param stackTrace Java stack trace.
      */
-    JavaException(const std::string &message, const std::string &className, std::string stackTrace);
+    JavaException(const StringLikeWrapper &message, const StringLikeWrapper &className,
+                  const StringLikeWrapper &stackTrace);
 
     /**
      * Creates an exception using native (GraalVM) Java exception handle
@@ -33,7 +38,7 @@ struct DXFCPP_EXPORT JavaException : public std::runtime_error {
      * @param exceptionHandle The native Java exception handle.
      * @return An exception.
      */
-    static JavaException create(void* exceptionHandle);
+    static JavaException create(void *exceptionHandle);
 
     /// Throws a JavaException if it exists (i.e. intercepted by Graal SDK)
     static void throwIfJavaThreadExceptionExists();
@@ -87,14 +92,6 @@ struct DXFCPP_EXPORT JavaException : public std::runtime_error {
 
         return v;
     }
-
-    /**
-     * @return dxFeed Graal CXX API stack trace + Java (GraalVM) exception's stack trace.
-     */
-    const std::string &getStackTrace() const &;
-
-  private:
-    std::string stackTrace_;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/exceptions/RuntimeException.hpp
+++ b/include/dxfeed_graal_cpp_api/exceptions/RuntimeException.hpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 Devexperts LLC.
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include "../internal/Conf.hpp"
+
+#include "../internal/Common.hpp"
+
+DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251 4275)
+
+#include <stdexcept>
+#include <string>
+
+DXFCPP_BEGIN_NAMESPACE
+
+/**
+ * A runtime axception with stacktrace
+ */
+struct DXFCPP_EXPORT RuntimeException : std::runtime_error {
+    /**
+     * Constructs a runtime exception.
+     *
+     * @param message The exception's message.
+     * @param additionalStackTrace The additional stacktrace that will be concatenated with current stacktrace.
+     */
+    explicit RuntimeException(const StringLikeWrapper& message, const StringLikeWrapper& additionalStackTrace = "");
+
+    /**
+     * @return The current stacktrace + the additional stacktrace if present.
+     */
+    const std::string& getStackTrace() const &;
+private:
+    std::string stackTrace_;
+};
+
+DXFCPP_END_NAMESPACE
+
+DXFCPP_EXPORT std::ostream &operator<<(std::ostream &os, const dxfcpp::RuntimeException &e);
+
+DXFCXX_DISABLE_MSC_WARNINGS_POP()

--- a/include/dxfeed_graal_cpp_api/internal/Common.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/Common.hpp
@@ -742,7 +742,7 @@ struct StringLikeWrapper {
         if (auto sv = std::get_if<std::string_view>(&data_); sv) {
             auto sv2 = sv->substr(pos, count);
 
-            return {sv2.data(), sv->size()};
+            return {sv2.data(), sv2.size()};
         } else {
             return std::get<std::string>(data_).substr(pos, count);
         }

--- a/include/dxfeed_graal_cpp_api/internal/TimeFormat.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/TimeFormat.hpp
@@ -19,7 +19,7 @@ DXFCPP_BEGIN_NAMESPACE
  *
  * Some methods that are not marked `noexcept` may throw exceptions:
  *
- * @throws std::invalid_argument if handle is invalid.
+ * @throws InvalidArgumentException if handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend
  * @throws GraalException if something happened with the GraalVM
  */

--- a/include/dxfeed_graal_cpp_api/internal/utils/CmdArgsUtils.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/utils/CmdArgsUtils.hpp
@@ -107,10 +107,10 @@ struct DXFCPP_EXPORT CmdArgsUtils final {
      * "all" or "*" will be converted to all types.
      *
      * @param types The comma-separated list of event types.
-     * @return The created set of parsed types.
+     * @return The created pair of set of parsed types and vector unknown types.
      */
-    static std::unordered_set<std::reference_wrapper<const EventTypeEnum>>
-    parseTypes(const std::string &types) noexcept;
+    static std::pair<std::unordered_set<std::reference_wrapper<const EventTypeEnum>>, std::vector<std::string>>
+    parseTypes(const std::string &types);
 
     /**
      * Parses an input string and returns a set of event types.
@@ -118,9 +118,10 @@ struct DXFCPP_EXPORT CmdArgsUtils final {
      * "all" or "*" will be converted to all types.
      *
      * @param types The comma-separated list of event types.
-     * @return The created set of parsed types.
+     * @return The created pair of set of parsed types and vector unknown types.
      */
-    static std::unordered_set<std::reference_wrapper<const EventTypeEnum>> parseTypes(const char *types) noexcept {
+    static std::pair<std::unordered_set<std::reference_wrapper<const EventTypeEnum>>, std::vector<std::string>>
+    parseTypes(const char *types) {
         return parseTypes(std::string(types));
     }
 
@@ -130,9 +131,10 @@ struct DXFCPP_EXPORT CmdArgsUtils final {
      * "all" or "*" will be converted to all types.
      *
      * @param types The comma-separated list of event types.
-     * @return The created set of parsed types.
+     * @return The created pair of set of parsed types and vector unknown types.
      */
-    static std::unordered_set<std::reference_wrapper<const EventTypeEnum>> parseTypes(std::string_view types) noexcept {
+    static std::pair<std::unordered_set<std::reference_wrapper<const EventTypeEnum>>, std::vector<std::string>>
+    parseTypes(std::string_view types) {
         return parseTypes(types.data());
     }
 
@@ -142,10 +144,10 @@ struct DXFCPP_EXPORT CmdArgsUtils final {
      * "all" or "*" will be converted to all types.
      *
      * @param types The comma-separated list of event types.
-     * @return The created set of parsed types.
+     * @return The created pair of set of parsed types and vector unknown types.
      */
-    static std::unordered_set<std::reference_wrapper<const EventTypeEnum>>
-    parseTypes(std::optional<std::string> types) noexcept;
+    static std::pair<std::unordered_set<std::reference_wrapper<const EventTypeEnum>>, std::vector<std::string>>
+    parseTypes(std::optional<std::string> types);
 
     /**
      * Parses the input collection of strings and returns a collection of key-value properties.

--- a/include/dxfeed_graal_cpp_api/internal/utils/StringUtils.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/utils/StringUtils.hpp
@@ -217,14 +217,16 @@ std::string namesToString(It begin, It end) {
     return result + "]";
 }
 
-template <typename It> std::string elementsToString(It begin, It end) {
-    std::string result{"["};
+template <typename It>
+std::string elementsToString(It begin, It end, const std::string &prefix = "[", const std::string &postfix = "[",
+                             const std::string &separator = ", ") {
+    std::string result{prefix};
 
     for (auto it = begin; it != end; it++) {
-        result += String::EMPTY + toStringAny(*it) + (std::next(it) == end ? "" : ", ");
+        result += String::EMPTY + toStringAny(*it) + (std::next(it) == end ? "" : separator);
     }
 
-    return result + "]";
+    return result + postfix;
 }
 
 DXFCPP_EXPORT std::string encodeChar(std::int16_t c);

--- a/include/dxfeed_graal_cpp_api/ipf/InstrumentProfile.hpp
+++ b/include/dxfeed_graal_cpp_api/ipf/InstrumentProfile.hpp
@@ -775,7 +775,7 @@ struct DXFCPP_EXPORT InstrumentProfile final : public RequireMakeShared<Instrume
          *
          * @param list The pointer to the dxFeed Graal SDK list of structures.
          * @return The vector of objects of current type
-         * @throws std::invalid_argument
+         * @throws InvalidArgumentException
          */
         static std::vector<Ptr> fromGraal(void *list);
     };

--- a/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXEndpoint.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXEndpoint.hpp
@@ -28,7 +28,7 @@ namespace isolated::api::IsolatedDXEndpoint {
  * Calls the Graal SDK function `dxfg_DXEndpoint_close` in isolation.
  *
  * @param endpoint The endpoint's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -38,7 +38,7 @@ void /* int32_t */ close(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::D
  * Calls the Graal SDK function `dxfg_DXEndpoint_closeAndAwaitTermination` in isolation.
  *
  * @param endpoint The endpoint's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -52,7 +52,7 @@ closeAndAwaitTermination(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::D
  *
  * @param endpoint The endpoint's handle.
  * @param user The user's name.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -64,7 +64,7 @@ void /* int32_t */ user(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DX
  *
  * @param endpoint The endpoint's handle.
  * @param password The user's password.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -75,7 +75,7 @@ void /* int32_t */ password(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp
  * Calls the Graal SDK function `dxfg_DXEndpoint_connect` in isolation.
  *
  * @param endpoint The endpoint's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -85,7 +85,7 @@ void connect(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &
  * Calls the Graal SDK function `dxfg_DXEndpoint_reconnect` in isolation.
  *
  * @param endpoint The endpoint's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -95,7 +95,7 @@ void reconnect(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint>
  * Calls the Graal SDK function `dxfg_DXEndpoint_disconnect` in isolation.
  *
  * @param endpoint The endpoint's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -105,7 +105,7 @@ void disconnect(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint
  * Calls the Graal SDK function `dxfg_DXEndpoint_disconnectAndClear` in isolation.
  *
  * @param endpoint The endpoint's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -115,7 +115,7 @@ void disconnectAndClear(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DX
  * Calls the Graal SDK function `dxfg_DXEndpoint_awaitProcessed` in isolation.
  *
  * @param endpoint The endpoint's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -125,7 +125,7 @@ void awaitProcessed(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndp
  * Calls the Graal SDK function `dxfg_DXEndpoint_awaitNotConnected` in isolation.
  *
  * @param endpoint The endpoint's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -136,7 +136,7 @@ void awaitNotConnected(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXE
  *
  * @param endpoint The endpoint's handle.
  * @return The endpoint's state.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -147,7 +147,7 @@ dxfcpp::DXEndpoint::State getState(/* dxfg_endpoint_t* */ const JavaObjectHandle
  *
  * @param endpoint The endpoint's handle.
  * @param listener The listener's handle.
- * @throws std::invalid_argument if the endpoint handle or listener handle is invalid.
+ * @throws InvalidArgumentException if the endpoint handle or listener handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -161,7 +161,7 @@ void addStateChangeListener(
  *
  * @param endpoint The endpoint's handle.
  * @param listener The listener's handle.
- * @throws std::invalid_argument if the endpoint handle or listener is invalid.
+ * @throws InvalidArgumentException if the endpoint handle or listener is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -175,7 +175,7 @@ void removeStateChangeListener(
  *
  * @param endpoint The endpoint's handle.
  * @return dxFeed Graal SDK DXFeed's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -186,7 +186,7 @@ void * /* dxfg_feed_t* */ getFeed(/* dxfg_endpoint_t * */ const JavaObjectHandle
  *
  * @param endpoint The endpoint's handle.
  * @return dxFeed Graal SDK DXPublisher's handle.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -201,7 +201,7 @@ getPublisher(/* dxfg_endpoint_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint> 
  *
  * @param endpoint The endpoint's handle.
  * @return A set of event types.
- * @throws std::invalid_argument if endpoint handle is invalid.
+ * @throws InvalidArgumentException if endpoint handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -223,7 +223,7 @@ void * /* dxfg_endpoint_builder_t* */ create();
  * Calls the Graal SDK function `dxfg_DXEndpoint_Builder_withRole` in isolation.
  * @param builder The DXEndpoint::Builder's handle.
  * @param role The endpoint's role.
- * @throws std::invalid_argument if DXEndpoint::Builder's handle is invalid.
+ * @throws InvalidArgumentException if DXEndpoint::Builder's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -239,7 +239,7 @@ withRole(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::DXEndpoi
  * @param builder The DXEndpoint::Builder's handle.
  * @param key The endpoint's property key.
  * @param value The endpoint's property value.
- * @throws std::invalid_argument if DXEndpoint::Builder's handle is invalid.
+ * @throws InvalidArgumentException if DXEndpoint::Builder's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -251,7 +251,7 @@ withProperty(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::DXEn
  * Calls the Graal SDK function `dxfg_DXEndpoint_Builder_withProperties` in isolation.
  * @param builder The DXEndpoint::Builder's handle.
  * @param filePath The file with properties.
- * @throws std::invalid_argument if DXEndpoint::Builder's handle is invalid.
+ * @throws InvalidArgumentException if DXEndpoint::Builder's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -263,7 +263,7 @@ withProperties(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::DX
  * Calls the Graal SDK function `dxfg_DXEndpoint_Builder_supportsProperty` in isolation.
  * @param builder The DXEndpoint::Builder's handle.
  * @param key The endpoint's property key to check.
- * @throws std::invalid_argument if DXEndpoint::Builder's handle is invalid.
+ * @throws InvalidArgumentException if DXEndpoint::Builder's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -276,7 +276,7 @@ supportsProperty(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::
  * @param builder The DXEndpoint::Builder's handle.
  * @return The DXEndpoint's handle.
  *
- * @throws std::invalid_argument if DXEndpoint::Builder's handle is invalid.
+ * @throws InvalidArgumentException if DXEndpoint::Builder's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -293,7 +293,7 @@ namespace StateChangeListener {
  * @param userData User data, which is placed each time as a callback parameter when called from listener.
  * @return The DXEndpointStateChangeListener's handle.
  *
- * @throws std::invalid_argument if userFunc is nullptr.
+ * @throws InvalidArgumentException if userFunc is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */

--- a/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXFeedSubscription.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXFeedSubscription.hpp
@@ -30,7 +30,7 @@ create(/* dxfg_event_clazz_t */ const EventTypeEnum &eventType);
  *
  * @param eventClassList The subscription's event types.
  *
- * @throws std::invalid_argument if eventClassList is nullptr.
+ * @throws InvalidArgumentException if eventClassList is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -46,7 +46,7 @@ create(/* dxfg_event_clazz_list_t * */ const std::unique_ptr<EventClassList> &ev
  *
  * @param sub The subscription's handle.
  * @return `true` if subscription is closed.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -56,7 +56,7 @@ bool /* int32_t */ isClosed(/* dxfg_subscription_t * */ const JavaObjectHandle<D
  * Calls the Graal SDK function `dxfg_DXFeedSubscription_close` in isolation.
  *
  * @param sub The subscription's handle.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -72,7 +72,7 @@ void /* int32_t */ close(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFe
  * Calls the Graal SDK function `dxfg_DXFeedSubscription_clear` in isolation.
  *
  * @param sub The subscription's handle.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -83,7 +83,7 @@ void /* int32_t */ clear(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFe
  *
  * @param sub The subscription's handle.
  * @return The subscription's symbols.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -95,7 +95,7 @@ getSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription
  *
  * @param sub The subscription's handle.
  * @return The subscription's decorated symbols.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -110,7 +110,7 @@ getDecoratedSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSub
  *
  * @param sub The subscription's handle.
  * @param symbols The subscription's symbols.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid or the symbols is nullptr.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid or the symbols is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -122,7 +122,7 @@ void /* int32_t */ setSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle
  *
  * @param sub The subscription's handle.
  * @param symbol The subscription's symbol.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid or the symbol is nullptr.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid or the symbol is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -134,7 +134,7 @@ void /* int32_t */ addSymbol(/* dxfg_subscription_t * */ const JavaObjectHandle<
  *
  * @param sub The subscription's handle.
  * @param symbols The subscription's symbols.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid or the symbols is nullptr.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid or the symbols is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -146,7 +146,7 @@ void /* int32_t */ addSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle
  *
  * @param sub The subscription's handle.
  * @param symbol The subscription's symbol.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid or the symbol is nullptr.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid or the symbol is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -158,7 +158,7 @@ void /* int32_t */ removeSymbol(/* dxfg_subscription_t * */ const JavaObjectHand
  *
  * @param sub The subscription's handle.
  * @param symbols The subscription's symbols.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid or the symbols is nullptr.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid or the symbols is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -173,7 +173,7 @@ void /* int32_t */ removeSymbols(/* dxfg_subscription_t * */ const JavaObjectHan
  * Calls the Graal SDK function `dxfg_DXFeedSubscription_getAggregationPeriod` in isolation.
  *
  * @param sub The subscription's handle.
- * @throws std::invalid_argument if DXFeedSubscription's handle is invalid.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -185,7 +185,7 @@ getAggregationPeriod(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSu
  *
  * @param sub The subscription's handle.
  * @param period The period's handle.
- * @throws std::invalid_argument if DXFeedSubscription's handle or period's handle is invalid.
+ * @throws InvalidArgumentException if DXFeedSubscription's handle or period's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -197,7 +197,7 @@ getAggregationPeriod(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSu
  *
  * @param sub The subscription's handle.
  * @param listener The listener's handle.
- * @throws std::invalid_argument if DXFeedSubscription's or DXFeedEventListener's handle is invalid.
+ * @throws InvalidArgumentException if DXFeedSubscription's or DXFeedEventListener's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -213,7 +213,7 @@ addEventListener(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscr
  *
  * @param sub The subscription's handle.
  * @param listener The listener's handle.
- * @throws std::invalid_argument if DXFeedSubscription's or ObservableSubscriptionChangeListener's handle
+ * @throws InvalidArgumentException if DXFeedSubscription's or ObservableSubscriptionChangeListener's handle
  * is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
@@ -228,7 +228,7 @@ void /* int32_t */ addChangeListener(
  *
  * @param sub The subscription's handle.
  * @param listener The listener's handle.
- * @throws std::invalid_argument if DXFeedSubscription's or ObservableSubscriptionChangeListener's handle
+ * @throws InvalidArgumentException if DXFeedSubscription's or ObservableSubscriptionChangeListener's handle
  * is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
@@ -253,7 +253,7 @@ namespace DXFeedEventListener {
  * @param userData User data, which is placed each time as a callback parameter when called from listener.
  * @return The DXFeedEventListener's handle.
  *
- * @throws std::invalid_argument if userFunc is nullptr.
+ * @throws InvalidArgumentException if userFunc is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */

--- a/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXPublisher.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXPublisher.hpp
@@ -20,7 +20,7 @@ namespace isolated::api::IsolatedDXPublisher {
  *
  * @param publisher The publisher's handle.
  * @param events Events to be published.
- * @throws std::invalid_argument if publisher handle is invalid or events' pointer is nullptr.
+ * @throws InvalidArgumentException if publisher handle is invalid or events' pointer is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -32,7 +32,7 @@ void /* int32_t */ publishEvents(/* dxfg_publisher_t * */ const JavaObjectHandle
  *
  * @param publisher The publisher's handle.
  * @param eventType The event type.
- * @throws std::invalid_argument if publisher handle is invalid.
+ * @throws InvalidArgumentException if publisher handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  * @return The underlying observable subscription's handle.

--- a/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXPublisherObservableSubscription.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXPublisherObservableSubscription.hpp
@@ -19,7 +19,7 @@ namespace isolated::api::IsolatedDXPublisherObservableSubscription {
  *
  * @param sub The subscription's handle.
  * @return Returns `true` if this subscription is closed.
- * @throws std::invalid_argument if DXPublisherObservableSubscription's handle is invalid.
+ * @throws InvalidArgumentException if DXPublisherObservableSubscription's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -31,7 +31,7 @@ isClosed(/* dxfg_observable_subscription_t * */ const JavaObjectHandle<DXPublish
  *
  * @param sub The subscription's handle.
  * @return The event types set.
- * @throws std::invalid_argument if DXPublisherObservableSubscription's handle is invalid.
+ * @throws InvalidArgumentException if DXPublisherObservableSubscription's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -44,7 +44,7 @@ std::unordered_set<EventTypeEnum> /* dxfg_event_clazz_list_t* */ getEventTypes(
  * @param sub The subscription's handle.
  * @param eventType The type of event that is checked.
  * @return `true` if this subscription contains the corresponding event type.
- * @throws std::invalid_argument if DXPublisherObservableSubscription's handle is invalid.
+ * @throws InvalidArgumentException if DXPublisherObservableSubscription's handle is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -57,7 +57,7 @@ bool /* int32_t */ containsEventType(
  *
  * @param sub The subscription's handle.
  * @param listener The listener's handle.
- * @throws std::invalid_argument if DXPublisherObservableSubscription's or ObservableSubscriptionChangeListener's handle
+ * @throws InvalidArgumentException if DXPublisherObservableSubscription's or ObservableSubscriptionChangeListener's handle
  * is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
@@ -72,7 +72,7 @@ void /* int32_t */ addChangeListener(
  *
  * @param sub The subscription's handle.
  * @param listener The listener's handle.
- * @throws std::invalid_argument if DXPublisherObservableSubscription's or ObservableSubscriptionChangeListener's handle
+ * @throws InvalidArgumentException if DXPublisherObservableSubscription's or ObservableSubscriptionChangeListener's handle
  * is invalid.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.

--- a/include/dxfeed_graal_cpp_api/isolated/api/osub/IsolatedObservableSubscriptionChangeListener.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/api/osub/IsolatedObservableSubscriptionChangeListener.hpp
@@ -23,7 +23,7 @@ namespace isolated::api::IsolatedObservableSubscriptionChangeListener {
  * @param userData User data, which is placed each time as a callback parameter when called from listener.
  * @return The ObservableSubscriptionChangeListener's handle.
  *
- * @throws std::invalid_argument if functionSymbolsAdded or functionSymbolsRemoved or functionSubscriptionClosed is
+ * @throws InvalidArgumentException if functionSymbolsAdded or functionSymbolsRemoved or functionSubscriptionClosed is
  * nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.

--- a/include/dxfeed_graal_cpp_api/isolated/internal/IsolatedString.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/internal/IsolatedString.hpp
@@ -19,7 +19,7 @@ namespace IsolatedString {
  * @param string The pointer to C-string
  * @return `true` if OK.
  *
- * @throws std::invalid_argument if string is nullptr.
+ * @throws InvalidArgumentException if string is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -35,7 +35,7 @@ namespace IsolatedStringList {
  * @param stringList The pointer to dxFeed Graal SDK' string list.
  * @return `true` if OK.
  *
- * @throws std::invalid_argument if stringList is nullptr.
+ * @throws InvalidArgumentException if stringList is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */

--- a/include/dxfeed_graal_cpp_api/isolated/promise/IsolatedPromise.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/promise/IsolatedPromise.hpp
@@ -22,7 +22,7 @@ namespace isolated::promise::IsolatedPromise {
  *
  * @param promise The promise's handle.
  * @return `true` when computation has completed normally or exceptionally or was cancelled.
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -33,7 +33,7 @@ bool /* int32_t */ isDone(/* dxfg_promise_t * */ void* promise);
  *
  * @param promise The promise's handle.
  * @return `true` when computation has completed normally
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -44,7 +44,7 @@ bool /* int32_t */ hasResult(/* dxfg_promise_t * */ void* promise);
  *
  * @param promise The promise's handle.
  * @return `true` when computation has completed exceptionally or was cancelled.
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -55,7 +55,7 @@ bool /* int32_t */ hasException(/* dxfg_promise_t * */ void* promise);
  *
  * @param promise The promise's handle.
  * @return `true` when computation was cancelled.
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -66,7 +66,7 @@ bool /* int32_t */ isCancelled(/* dxfg_promise_t * */ void* promise);
  *
  * @param promise The promise's handle.
  * @return event by promise
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -77,7 +77,7 @@ std::shared_ptr<EventType> /* dxfg_event_type_t* */ getResult(/* dxfg_promise_ev
  *
  * @param promise The promise's handle.
  * @return events by promise
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -88,7 +88,7 @@ std::vector<std::shared_ptr<EventType>> /* dxfg_event_type_list* */ getResults(/
  *
  * @param promise The promise's handle.
  * @return exception by promise
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -98,7 +98,7 @@ JavaException /* dxfg_exception_t* */ getException(/* dxfg_promise_t * */ void* 
  * Calls the Graal SDK function `dxfg_Promise_await` in isolation.
  *
  * @param promise The promise's handle.
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -109,7 +109,7 @@ void /* int32_t */ await(/* dxfg_promise_t * */ void* promise);
  *
  * @param promise The promise's handle.
  * @param timeoutInMilliseconds The promise's timeout.
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -121,7 +121,7 @@ void /* int32_t */ await(/* dxfg_promise_t * */ void* promise, std::int32_t time
  * @param promise The promise's handle.
  * @param timeoutInMilliseconds The promise's timeout.
  * @return `true` if the computation has completed normally; `false` when wait timed out.
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */
@@ -131,7 +131,7 @@ bool /* int32_t */ awaitWithoutException(/* dxfg_promise_t * */ void* promise, s
  * Calls the Graal SDK function `dxfg_Promise_cancel` in isolation.
  *
  * @param promise The promise's handle.
- * @throws std::invalid_argument if promise handle is nullptr.
+ * @throws InvalidArgumentException if promise handle is nullptr.
  * @throws JavaException if something happened with the dxFeed API backend.
  * @throws GraalException if something happened with the GraalVM.
  */

--- a/include/dxfeed_graal_cpp_api/symbols/StringSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/symbols/StringSymbol.hpp
@@ -79,6 +79,7 @@ struct DXFCPP_EXPORT StringSymbol final {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -87,7 +88,7 @@ struct DXFCPP_EXPORT StringSymbol final {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
      */
     static StringSymbol fromGraal(void *graalNative);
 

--- a/include/dxfeed_graal_cpp_api/symbols/SymbolWrapper.hpp
+++ b/include/dxfeed_graal_cpp_api/symbols/SymbolWrapper.hpp
@@ -219,6 +219,7 @@ struct DXFCPP_EXPORT SymbolWrapper final {
      * Releases the memory occupied by the dxFeed Graal SDK structure (recursively if necessary).
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
+     * @throws InvalidArgumentException
      */
     static void freeGraal(void *graalNative);
 
@@ -227,7 +228,8 @@ struct DXFCPP_EXPORT SymbolWrapper final {
      *
      * @param graalNative The pointer to the dxFeed Graal SDK structure.
      * @return The object of current type.
-     * @throws std::invalid_argument
+     * @throws InvalidArgumentException
+     * @throws RuntimeException if symbol type is unknown
      */
     static SymbolWrapper fromGraal(void *graalNative);
 

--- a/samples/cpp/ConvertTapeFile/src/main.cpp
+++ b/samples/cpp/ConvertTapeFile/src/main.cpp
@@ -70,12 +70,8 @@ int main(int argc, char *argv[]) {
         // Wait until all data is processed and written, and then gracefully close output endpoint.
         outputEndpoint->awaitProcessed();
         outputEndpoint->closeAndAwaitTermination();
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 
     return 0;

--- a/samples/cpp/DxFeedConnect/src/main.cpp
+++ b/samples/cpp/DxFeedConnect/src/main.cpp
@@ -91,12 +91,8 @@ int main(int argc, char *argv[]) {
         }
 
         std::cin.get();
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 
     return 0;

--- a/samples/cpp/DxFeedConnect/src/main.cpp
+++ b/samples/cpp/DxFeedConnect/src/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) {
         auto endpoint = DXEndpoint::create()->connect(address);
 
         // Create a subscription with specified types attached to feed.
-        auto sub = endpoint->getFeed()->createSubscription(types);
+        auto sub = endpoint->getFeed()->createSubscription(types.first);
 
         // Add an event listener.
         sub->addEventListener([&ioMtx](const auto &events) {

--- a/samples/cpp/DxFeedFileParser/src/main.cpp
+++ b/samples/cpp/DxFeedFileParser/src/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
         auto feed = endpoint->getFeed();
 
         // Subscribe to a specified event and symbol.
-        auto sub = feed->createSubscription(types);
+        auto sub = feed->createSubscription(types.first);
         sub->addEventListener([&eventCounter, &ioMtx](const auto &events) {
             std::lock_guard lock{ioMtx};
 

--- a/samples/cpp/DxFeedFileParser/src/main.cpp
+++ b/samples/cpp/DxFeedFileParser/src/main.cpp
@@ -68,12 +68,8 @@ int main(int argc, char *argv[]) {
         // Close endpoint when we're done.
         // This method will gracefully close endpoint, waiting while data processing completes.
         endpoint->closeAndAwaitTermination();
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 
     return 0;

--- a/samples/cpp/DxFeedIpfConnect/src/main.cpp
+++ b/samples/cpp/DxFeedIpfConnect/src/main.cpp
@@ -79,11 +79,7 @@ int main(int argc, char *argv[]) {
         sub->addSymbols(getSymbols(ipfFile));
 
         std::this_thread::sleep_for(std::chrono::days(365));
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 }

--- a/samples/cpp/DxFeedIpfConnect/src/main.cpp
+++ b/samples/cpp/DxFeedIpfConnect/src/main.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
         auto types = CmdArgsUtils::parseTypes(argv[1]);
         auto ipfFile = argv[2];
 
-        auto sub = DXFeed::getInstance()->createSubscription(types);
+        auto sub = DXFeed::getInstance()->createSubscription(types.first);
 
         sub->addEventListener<MarketEvent>([](auto &&events) {
             for (auto &&event : events) {

--- a/samples/cpp/DxFeedLiveIpfSample/src/main.cpp
+++ b/samples/cpp/DxFeedLiveIpfSample/src/main.cpp
@@ -102,11 +102,7 @@ int main(int argc, char *argv[]) {
         std::this_thread::sleep_for(std::chrono::days(365));
 
         connection->close();
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 }

--- a/samples/cpp/DxFeedSample/src/main.cpp
+++ b/samples/cpp/DxFeedSample/src/main.cpp
@@ -75,11 +75,7 @@ Where:
         testQuoteAndTradeListener(symbol);
 
         std::cin.get();
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 }

--- a/samples/cpp/FetchDailyCandles/src/main.cpp
+++ b/samples/cpp/FetchDailyCandles/src/main.cpp
@@ -46,11 +46,7 @@ Where:
         std::cout << "Fetching last " << DAYS << " days of candles for " << baseSymbol << "\n";
 
         fetchAndPrint(candleSymbol, toTime, fromTime);
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 }

--- a/samples/cpp/OnDemandSample/src/main.cpp
+++ b/samples/cpp/OnDemandSample/src/main.cpp
@@ -53,11 +53,7 @@ int main(int /* argc */, char ** /* argv */) {
 
         // close endpoint completely to release resources and shutdown GraalVM
         onDemand->getEndpoint()->closeAndAwaitTermination();
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 }

--- a/samples/cpp/PrintQuoteEvents/src/main.cpp
+++ b/samples/cpp/PrintQuoteEvents/src/main.cpp
@@ -34,11 +34,7 @@ int main(int argc, char *argv[]) {
         subscription->addSymbols(symbol);
 
         std::cin.get();
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 }

--- a/samples/cpp/PublishProfiles/src/main.cpp
+++ b/samples/cpp/PublishProfiles/src/main.cpp
@@ -53,12 +53,8 @@ int main(int argc, char *argv[]) {
                 }));
 
         std::cin.get();
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 
     return 0;

--- a/samples/cpp/ScheduleSample/src/main.cpp
+++ b/samples/cpp/ScheduleSample/src/main.cpp
@@ -225,11 +225,7 @@ int main(int argc, char *argv[]) {
         printCurrentSession(profile, time);
         printNextTradingSession(profile, time);
         printNearestTradingSession(profile, time);
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 }

--- a/samples/cpp/WriteTapeFile/src/main.cpp
+++ b/samples/cpp/WriteTapeFile/src/main.cpp
@@ -33,12 +33,8 @@ int main() {
         // Wait until all data is written, close, and wait until it closes.
         endpoint->awaitProcessed();
         endpoint->closeAndAwaitTermination();
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     }
 
     return 0;

--- a/src/api/DXEndpoint.cpp
+++ b/src/api/DXEndpoint.cpp
@@ -120,7 +120,7 @@ std::unordered_map<DXEndpoint::Role, std::shared_ptr<DXEndpoint>> DXEndpoint::Im
 std::shared_ptr<DXEndpoint> DXEndpoint::create(void *endpointHandle, DXEndpoint::Role role,
                                                const std::unordered_map<std::string, std::string> &properties) {
     if (endpointHandle == nullptr) {
-        throw std::invalid_argument("Unable to create DXEndpoint. The `endpointHandle` is nullptr");
+        throw InvalidArgumentException("Unable to create DXEndpoint. The `endpointHandle` is nullptr");
     }
 
     if constexpr (Debugger::isDebug) {

--- a/src/api/osub/IndexedEventSubscriptionSymbol.cpp
+++ b/src/api/osub/IndexedEventSubscriptionSymbol.cpp
@@ -48,7 +48,7 @@ IndexedEventSubscriptionSymbol IndexedEventSubscriptionSymbol::fromGraal(void *g
     }
 
     if (graalNative == nullptr) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to create IndexedEventSubscriptionSymbol. The `graalNative` parameter is nullptr");
     }
 

--- a/src/api/osub/TimeSeriesSubscriptionSymbol.cpp
+++ b/src/api/osub/TimeSeriesSubscriptionSymbol.cpp
@@ -51,7 +51,7 @@ TimeSeriesSubscriptionSymbol TimeSeriesSubscriptionSymbol::fromGraal(void *graal
     }
 
     if (graalNative == nullptr) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to create TimeSeriesSubscriptionSymbol. The `graalNative` parameter is nullptr");
     }
 

--- a/src/event/EventMapper.cpp
+++ b/src/event/EventMapper.cpp
@@ -18,7 +18,7 @@ DXFCPP_BEGIN_NAMESPACE
 
 std::shared_ptr<EventType> EventMapper::fromGraal(void *graalNativeEvent) {
     if (!graalNativeEvent) {
-        throw std::invalid_argument("The `graalNativeEvent` is nullptr");
+        throw InvalidArgumentException("The `graalNativeEvent` is nullptr");
     }
 
     // TODO: implement other types [EN-8235]
@@ -34,7 +34,7 @@ std::shared_ptr<EventType> EventMapper::fromGraal(void *graalNativeEvent) {
     case DXFG_EVENT_CANDLE:
         return Candle::fromGraal(e);
     case DXFG_EVENT_DAILY_CANDLE:
-        throw std::invalid_argument("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
+        throw InvalidArgumentException("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
     case DXFG_EVENT_UNDERLYING:
         return Underlying::fromGraal(e);
     case DXFG_EVENT_THEO_PRICE:
@@ -44,13 +44,13 @@ std::shared_ptr<EventType> EventMapper::fromGraal(void *graalNativeEvent) {
     case DXFG_EVENT_TRADE_ETH:
         return TradeETH::fromGraal(e);
     case DXFG_EVENT_CONFIGURATION:
-        throw std::invalid_argument("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
+        throw InvalidArgumentException("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
     case DXFG_EVENT_MESSAGE:
         return Message::fromGraal(e);
     case DXFG_EVENT_TIME_AND_SALE:
         return TimeAndSale::fromGraal(e);
     case DXFG_EVENT_ORDER_BASE:
-        throw std::invalid_argument("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
+        throw InvalidArgumentException("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
     case DXFG_EVENT_ORDER:
         return Order::fromGraal(e);
     case DXFG_EVENT_ANALYTIC_ORDER:
@@ -64,7 +64,7 @@ std::shared_ptr<EventType> EventMapper::fromGraal(void *graalNativeEvent) {
     case DXFG_EVENT_OPTION_SALE:
         return OptionSale::fromGraal(e);
     default:
-        throw std::invalid_argument("Unknown event type: " + std::to_string(static_cast<int>(e->clazz)));
+        throw InvalidArgumentException("Unknown event type: " + std::to_string(static_cast<int>(e->clazz)));
     }
 }
 
@@ -115,7 +115,7 @@ void EventMapper::freeGraal(void *graalNativeEvent) {
 
         break;
     case DXFG_EVENT_DAILY_CANDLE:
-        throw std::invalid_argument("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
+        throw InvalidArgumentException("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
 
     case DXFG_EVENT_UNDERLYING:
         Underlying::freeGraal(e);
@@ -134,7 +134,7 @@ void EventMapper::freeGraal(void *graalNativeEvent) {
 
         break;
     case DXFG_EVENT_CONFIGURATION:
-        throw std::invalid_argument("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
+        throw InvalidArgumentException("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
 
     case DXFG_EVENT_MESSAGE:
         Message::freeGraal(e);
@@ -145,7 +145,7 @@ void EventMapper::freeGraal(void *graalNativeEvent) {
 
         break;
     case DXFG_EVENT_ORDER_BASE:
-        throw std::invalid_argument("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
+        throw InvalidArgumentException("Not emplemented event type: " + std::to_string(static_cast<int>(e->clazz)));
 
     case DXFG_EVENT_ORDER:
         Order::freeGraal(e);
@@ -172,7 +172,7 @@ void EventMapper::freeGraal(void *graalNativeEvent) {
 
         break;
     default:
-        throw std::invalid_argument("Unknown event type: " + std::to_string(static_cast<int>(e->clazz)));
+        throw InvalidArgumentException("Unknown event type: " + std::to_string(static_cast<int>(e->clazz)));
     }
 }
 

--- a/src/event/candle/Candle.cpp
+++ b/src/event/candle/Candle.cpp
@@ -84,11 +84,11 @@ void Candle::freeGraalData(void *graalNative) noexcept {
 
 std::shared_ptr<Candle> Candle::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Candle. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Candle. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_CANDLE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Candle. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_CANDLE))));
@@ -120,7 +120,7 @@ void Candle::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_CANDLE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Candle's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_CANDLE))));

--- a/src/event/market/AnalyticOrder.cpp
+++ b/src/event/market/AnalyticOrder.cpp
@@ -49,11 +49,11 @@ void AnalyticOrder::fillGraalData(void *graalNative) const noexcept {
 
 std::shared_ptr<AnalyticOrder> AnalyticOrder::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create AnalyticOrder. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create AnalyticOrder. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_ANALYTIC_ORDER) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create AnalyticOrder. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_ANALYTIC_ORDER))));
@@ -92,7 +92,7 @@ void AnalyticOrder::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_ANALYTIC_ORDER) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free AnalyticOrder's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_ANALYTIC_ORDER))));

--- a/src/event/market/OptionSale.cpp
+++ b/src/event/market/OptionSale.cpp
@@ -90,11 +90,11 @@ void OptionSale::freeGraalData(void *graalNative) noexcept {
 
 std::shared_ptr<OptionSale> OptionSale::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create OptionSale. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create OptionSale. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_OPTION_SALE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Order. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_OPTION_SALE))));

--- a/src/event/market/Order.cpp
+++ b/src/event/market/Order.cpp
@@ -55,11 +55,11 @@ void Order::freeGraalData(void *graalNative) noexcept {
 
 std::shared_ptr<Order> Order::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Order. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Order. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_ORDER) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Order. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_ORDER))));
@@ -94,7 +94,7 @@ void Order::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_ORDER) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Order's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_ORDER))));

--- a/src/event/market/OtcMarketsOrder.cpp
+++ b/src/event/market/OtcMarketsOrder.cpp
@@ -47,11 +47,11 @@ void OtcMarketsOrder::fillGraalData(void *graalNative) const noexcept {
 
 OtcMarketsOrder::Ptr OtcMarketsOrder::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create OtcMarketsOrder. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create OtcMarketsOrder. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_OTC_MARKETS_ORDER) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create OtcMarketsOrder. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_OTC_MARKETS_ORDER))));
@@ -89,7 +89,7 @@ void OtcMarketsOrder::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_OTC_MARKETS_ORDER) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free OtcMarketsOrder's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_OTC_MARKETS_ORDER))));

--- a/src/event/market/Profile.cpp
+++ b/src/event/market/Profile.cpp
@@ -92,11 +92,11 @@ void Profile::freeGraalData(void *graalNative) noexcept {
 
 std::shared_ptr<Profile> Profile::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Profile. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Profile. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_PROFILE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Profile. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_PROFILE))));
@@ -143,7 +143,7 @@ void Profile::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_PROFILE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Profile's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_PROFILE))));

--- a/src/event/market/Quote.cpp
+++ b/src/event/market/Quote.cpp
@@ -113,11 +113,11 @@ std::string Quote::toString() const {
 
 std::shared_ptr<Quote> Quote::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Quote. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Quote. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != DXFG_EVENT_QUOTE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Quote. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_QUOTE))));
@@ -148,7 +148,7 @@ void Quote::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_QUOTE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Quote's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_QUOTE))));

--- a/src/event/market/SpreadOrder.cpp
+++ b/src/event/market/SpreadOrder.cpp
@@ -55,11 +55,11 @@ void SpreadOrder::freeGraalData(void *graalNative) noexcept {
 
 std::shared_ptr<SpreadOrder> SpreadOrder::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create SpreadOrder. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create SpreadOrder. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != DXFG_EVENT_SPREAD_ORDER) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create SpreadOrder. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_SPREAD_ORDER))));
@@ -94,7 +94,7 @@ void SpreadOrder::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != DXFG_EVENT_SPREAD_ORDER) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free SpreadOrder's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_SPREAD_ORDER))));

--- a/src/event/market/Summary.cpp
+++ b/src/event/market/Summary.cpp
@@ -67,11 +67,11 @@ void Summary::fillGraalData(void *graalNative) const noexcept {
 
 std::shared_ptr<Summary> Summary::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Summary. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Summary. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_SUMMARY) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Summary. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_SUMMARY))));
@@ -115,7 +115,7 @@ void Summary::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_SUMMARY) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Summary's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_SUMMARY))));

--- a/src/event/market/TimeAndSale.cpp
+++ b/src/event/market/TimeAndSale.cpp
@@ -89,11 +89,11 @@ void TimeAndSale::freeGraalData(void *graalNative) noexcept {
 
 std::shared_ptr<TimeAndSale> TimeAndSale::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create TimeAndSale. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create TimeAndSale. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_TIME_AND_SALE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create TimeAndSale. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_TIME_AND_SALE))));
@@ -139,7 +139,7 @@ void TimeAndSale::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_TIME_AND_SALE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free TimeAndSale's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_TIME_AND_SALE))));

--- a/src/event/market/Trade.cpp
+++ b/src/event/market/Trade.cpp
@@ -42,11 +42,11 @@ void Trade::fillGraalData(void *graalNative) const noexcept {
 
 std::shared_ptr<Trade> Trade::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Trade. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Trade. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_TRADE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Trade. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_TRADE))));
@@ -81,7 +81,7 @@ void Trade::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_TRADE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Trade's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_TRADE))));

--- a/src/event/market/TradeETH.cpp
+++ b/src/event/market/TradeETH.cpp
@@ -42,11 +42,11 @@ void TradeETH::fillGraalData(void *graalNative) const noexcept {
 
 std::shared_ptr<TradeETH> TradeETH::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create TradeETH. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create TradeETH. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_TRADE_ETH) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create TradeETH. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_TRADE_ETH))));
@@ -81,7 +81,7 @@ void TradeETH::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_TRADE_ETH) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free TradeETH's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_TRADE_ETH))));

--- a/src/event/misc/Message.cpp
+++ b/src/event/misc/Message.cpp
@@ -65,11 +65,11 @@ void Message::freeGraalData(void *graalNative) noexcept {
 
 std::shared_ptr<Message> Message::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Message. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Message. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_MESSAGE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Message. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_MESSAGE))));
@@ -100,7 +100,7 @@ void Message::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_MESSAGE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Message's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_MESSAGE))));

--- a/src/event/option/Greeks.cpp
+++ b/src/event/option/Greeks.cpp
@@ -65,11 +65,11 @@ void Greeks::fillGraalData(void *graalNative) const noexcept {
 
 std::shared_ptr<Greeks> Greeks::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Greeks. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Greeks. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_GREEKS) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Greeks. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_GREEKS))));
@@ -111,7 +111,7 @@ void Greeks::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_GREEKS) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Greeks's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_GREEKS))));

--- a/src/event/option/Series.cpp
+++ b/src/event/option/Series.cpp
@@ -69,11 +69,11 @@ void Series::fillGraalData(void *graalNative) const noexcept {
 
 std::shared_ptr<Series> Series::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Series. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Series. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_SERIES) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Series. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_SERIES))));
@@ -115,7 +115,7 @@ void Series::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_SERIES) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Series's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_SERIES))));

--- a/src/event/option/TheoPrice.cpp
+++ b/src/event/option/TheoPrice.cpp
@@ -63,11 +63,11 @@ void TheoPrice::fillGraalData(void *graalNative) const noexcept {
 
 std::shared_ptr<TheoPrice> TheoPrice::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create TheoPrice. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create TheoPrice. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_THEO_PRICE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create TheoPrice. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_THEO_PRICE))));
@@ -108,7 +108,7 @@ void TheoPrice::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_THEO_PRICE) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free TheoPrice's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_THEO_PRICE))));

--- a/src/event/option/Underlying.cpp
+++ b/src/event/option/Underlying.cpp
@@ -63,11 +63,11 @@ void Underlying::fillGraalData(void *graalNative) const noexcept {
 
 std::shared_ptr<Underlying> Underlying::fromGraal(void *graalNative) {
     if (!graalNative) {
-        throw std::invalid_argument("Unable to create Underlying. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create Underlying. The `graalNative` parameter is nullptr");
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_UNDERLYING) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to create Underlying. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_UNDERLYING))));
@@ -109,7 +109,7 @@ void Underlying::freeGraal(void *graalNative) {
     }
 
     if (static_cast<dxfg_event_type_t *>(graalNative)->clazz != dxfg_event_clazz_t::DXFG_EVENT_UNDERLYING) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             fmt::format("Unable to free Underlying's Graal data. Wrong event class {}! Expected: {}.",
                         std::to_string(static_cast<int>(static_cast<dxfg_event_type_t *>(graalNative)->clazz)),
                         std::to_string(static_cast<int>(dxfg_event_clazz_t::DXFG_EVENT_UNDERLYING))));

--- a/src/exceptions/GraalException.cpp
+++ b/src/exceptions/GraalException.cpp
@@ -13,12 +13,7 @@ DXFCPP_BEGIN_NAMESPACE
 std::string stackTraceToString(const boost::stacktrace::stacktrace &stacktrace);
 
 GraalException::GraalException(CEntryPointErrorsEnum entryPointErrorsEnum)
-    : std::runtime_error(createMessage(entryPointErrorsEnum)),
-      stackTrace_{stackTraceToString(boost::stacktrace::stacktrace())} {
-}
-
-const std::string &GraalException::getStackTrace() const & {
-    return stackTrace_;
+    : RuntimeException(createMessage(entryPointErrorsEnum)) {
 }
 
 DXFCPP_END_NAMESPACE

--- a/src/exceptions/InvalidArgumentException.cpp
+++ b/src/exceptions/InvalidArgumentException.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 Devexperts LLC.
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dxfeed_graal_cpp_api/api.hpp>
+
+#include <boost/stacktrace.hpp>
+#include <fmt/format.h>
+
+DXFCPP_BEGIN_NAMESPACE
+
+InvalidArgumentException::InvalidArgumentException(const StringLikeWrapper &message,
+                                                   const StringLikeWrapper &additionalStackTrace)
+    : RuntimeException(message, additionalStackTrace) {
+}
+
+DXFCPP_END_NAMESPACE

--- a/src/exceptions/JavaException.cpp
+++ b/src/exceptions/JavaException.cpp
@@ -10,6 +10,8 @@
 
 DXFCPP_BEGIN_NAMESPACE
 
+std::string stackTraceToString(const boost::stacktrace::stacktrace &stacktrace);
+
 void JavaException::throwIfJavaThreadExceptionExists() {
     dxfg_exception_t *exception = runIsolatedThrow([](auto threadHandle) {
         return dxfg_get_and_clear_thread_exception_t(static_cast<graal_isolatethread_t *>(threadHandle));
@@ -36,64 +38,10 @@ void JavaException::throwException() {
     });
 }
 
-std::string stackTraceToString(const boost::stacktrace::stacktrace &stacktrace) {
-    std::string result;
-
-    for (auto &&frame : stacktrace) {
-        result += "\tat ";
-        auto frameString = boost::stacktrace::to_string(frame);
-
-        if (frameString.empty()) {
-            result += "\n";
-
-            continue;
-        }
-
-        std::string what;
-        std::size_t whereStart = 0;
-
-        auto foundIn = frameString.find(" in ");
-
-        if (foundIn != std::string::npos) {
-            what = frameString.substr(0, foundIn);
-            whereStart = foundIn + 4;
-        } else {
-            auto foundAt = frameString.find(" at ");
-
-            if (foundAt != std::string::npos) {
-                what = frameString.substr(0, foundAt);
-                whereStart = foundIn + 4;
-            } else {
-                whereStart = frameString.size();
-            }
-        }
-
-        if (whereStart == frameString.size()) {
-            what = frameString;
-
-            result += what + "\n";
-
-            continue;
-        }
-
-        auto foundLastSep = frameString.find_last_of("\\/");
-        std::string where;
-
-        if (foundLastSep != std::string::npos && foundLastSep < frameString.size() - 1) {
-            where = frameString.substr(foundLastSep + 1);
-        } else {
-            where = frameString.substr(whereStart);
-        }
-
-        result += fmt::format("{}({})\n", what, where);
-    }
-
-    return result;
-}
-
-JavaException::JavaException(const std::string &message, const std::string &className, std::string stackTrace)
-    : std::runtime_error(fmt::format("Java exception of type '{}' was thrown. {}", className, message)),
-      stackTrace_{std::move(stackTrace) + "\n" + stackTraceToString(boost::stacktrace::stacktrace())} {
+JavaException::JavaException(const StringLikeWrapper &message, const StringLikeWrapper &className,
+                             const StringLikeWrapper &stackTrace)
+    : RuntimeException(fmt::format("Java exception of type '{}' was thrown. {}", className.c_str(), message.c_str()),
+                       stackTrace) {
 }
 
 JavaException JavaException::create(void *exceptionHandle) {
@@ -104,10 +52,6 @@ JavaException JavaException::create(void *exceptionHandle) {
     auto *exception = dxfcpp::bit_cast<dxfg_exception_t *>(exceptionHandle);
 
     return {toString(exception->message), toString(exception->class_name), toString(exception->print_stack_trace)};
-}
-
-const std::string &JavaException::getStackTrace() const & {
-    return stackTrace_;
 }
 
 DXFCPP_END_NAMESPACE

--- a/src/exceptions/RuntimeException.cpp
+++ b/src/exceptions/RuntimeException.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2024 Devexperts LLC.
+// SPDX-License-Identifier: MPL-2.0
+
+#include <dxfeed_graal_cpp_api/api.hpp>
+
+#include <boost/stacktrace.hpp>
+#include <fmt/format.h>
+
+DXFCPP_BEGIN_NAMESPACE
+
+std::string stackTraceToString(const boost::stacktrace::stacktrace &stacktrace) {
+    std::string result;
+
+    for (auto &&frame : stacktrace) {
+        result += "\tat ";
+        auto frameString = boost::stacktrace::to_string(frame);
+
+        if (frameString.empty()) {
+            result += "\n";
+
+            continue;
+        }
+
+        std::string what;
+        std::size_t whereStart = 0;
+
+        auto foundIn = frameString.find(" in ");
+
+        if (foundIn != std::string::npos) {
+            what = frameString.substr(0, foundIn);
+            whereStart = foundIn + 4;
+        } else {
+            auto foundAt = frameString.find(" at ");
+
+            if (foundAt != std::string::npos) {
+                what = frameString.substr(0, foundAt);
+                whereStart = foundIn + 4;
+            } else {
+                whereStart = frameString.size();
+            }
+        }
+
+        if (whereStart == frameString.size()) {
+            what = frameString;
+
+            result += what + "\n";
+
+            continue;
+        }
+
+        auto foundLastSep = frameString.find_last_of("\\/");
+        std::string where;
+
+        if (foundLastSep != std::string::npos && foundLastSep < frameString.size() - 1) {
+            where = frameString.substr(foundLastSep + 1);
+        } else {
+            where = frameString.substr(whereStart);
+        }
+
+        result += fmt::format("{}({})\n", what, where);
+    }
+
+    return result;
+}
+
+RuntimeException::RuntimeException(const StringLikeWrapper &message, const StringLikeWrapper &additionalStackTrace)
+    : runtime_error(message.c_str()),
+      stackTrace_(additionalStackTrace.empty() ? stackTraceToString(boost::stacktrace::stacktrace())
+                                               : fmt::format("{}\n{}", additionalStackTrace.c_str(),
+                                                             stackTraceToString(boost::stacktrace::stacktrace()))) {
+}
+
+const std::string &RuntimeException::getStackTrace() const & {
+    return stackTrace_;
+}
+
+DXFCPP_END_NAMESPACE
+
+std::ostream &operator<<(std::ostream &os, const dxfcpp::RuntimeException &e) {
+    return os << fmt::format("{}\n{}", e.what(), e.getStackTrace());
+}

--- a/src/internal/Common.cpp
+++ b/src/internal/Common.cpp
@@ -5,3 +5,32 @@
 
 #include <dxfeed_graal_c_api/api.h>
 #include <dxfeed_graal_cpp_api/api.hpp>
+
+DXFCPP_BEGIN_NAMESPACE
+
+namespace day_util {
+std::int32_t getDayIdByYearMonthDay(std::int32_t year, std::int32_t month, std::int32_t day) {
+    if (month < 1 || month > 12) {
+        throw InvalidArgumentException("invalid month " + std::to_string(month));
+    }
+
+    std::int32_t dayOfYear = DAY_OF_YEAR[month] + day - 1;
+
+    if (month > 2 && year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) {
+        dayOfYear++;
+    }
+
+    return year * 365 + math_util::div(year - 1, 4) - math_util::div(year - 1, 100) + math_util::div(year - 1, 400) +
+           dayOfYear - 719527;
+}
+} // namespace day_util
+
+namespace util {
+
+inline void throwInvalidChar(char c, const std::string &name) {
+    throw InvalidArgumentException("Invalid " + name + ": " + encodeChar(c));
+}
+
+}
+
+DXFCPP_END_NAMESPACE

--- a/src/ipf/live/InstrumentProfileConnection.cpp
+++ b/src/ipf/live/InstrumentProfileConnection.cpp
@@ -66,7 +66,7 @@ InstrumentProfileConnection::createConnection(const std::string &address,
     std::shared_ptr<InstrumentProfileConnection> connection(new InstrumentProfileConnection{});
 
     if (!collector->handle_) {
-        throw std::invalid_argument("The collector's handle is invalid");
+        throw InvalidArgumentException("The collector's handle is invalid");
     }
 
     connection->id_ =

--- a/src/isolated/api/IsolatedDXEndpoint.cpp
+++ b/src/isolated/api/IsolatedDXEndpoint.cpp
@@ -13,7 +13,7 @@ namespace isolated::api::IsolatedDXEndpoint {
 void /* int32_t */
 close(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_close`. The `endpoint` handle is invalid");
     }
 
@@ -23,7 +23,7 @@ close(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoin
 void /* int32_t */
 closeAndAwaitTermination(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_closeAndAwaitTermination`. The `endpoint` handle is invalid");
     }
 
@@ -34,7 +34,7 @@ closeAndAwaitTermination(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::D
 void /* int32_t */ user(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint,
                         std::string_view user) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_user`. The `endpoint` handle is invalid");
     }
 
@@ -45,7 +45,7 @@ void /* int32_t */ user(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DX
 void /* int32_t */ password(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint,
                             std::string_view password) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_password`. The `endpoint` handle is invalid");
     }
 
@@ -55,7 +55,7 @@ void /* int32_t */ password(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp
 
 void connect(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint, std::string_view address) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_connect`. The `endpoint` handle is invalid");
     }
 
@@ -65,7 +65,7 @@ void connect(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &
 
 void reconnect(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_reconnect`. The `endpoint` handle is invalid");
     }
 
@@ -74,7 +74,7 @@ void reconnect(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint>
 
 void disconnect(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_disconnect`. The `endpoint` handle is invalid");
     }
 
@@ -83,7 +83,7 @@ void disconnect(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint
 
 void disconnectAndClear(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_disconnectAndClear`. The `endpoint` handle is invalid");
     }
 
@@ -93,7 +93,7 @@ void disconnectAndClear(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DX
 
 void awaitProcessed(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_awaitProcessed`. The `endpoint` handle is invalid");
     }
 
@@ -103,7 +103,7 @@ void awaitProcessed(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndp
 
 void awaitNotConnected(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_awaitNotConnected`. The `endpoint` handle is invalid");
     }
 
@@ -113,7 +113,7 @@ void awaitNotConnected(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXE
 
 dxfcpp::DXEndpoint::State getState(/* dxfg_endpoint_t* */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument("Unable to get state. The `endpoint` handle is invalid");
+        throw InvalidArgumentException("Unable to get state. The `endpoint` handle is invalid");
     }
 
     return graalStateToState(runGraalFunctionAndThrowIfLessThanZero(dxfg_DXEndpoint_getState,
@@ -126,11 +126,11 @@ void addStateChangeListener(
         &listener) {
 
     if (!endpoint) {
-        throw std::invalid_argument("Unable to add DXEndpointStateChangeListener. The `endpoint` handle is invalid");
+        throw InvalidArgumentException("Unable to add DXEndpointStateChangeListener. The `endpoint` handle is invalid");
     }
 
     if (!listener) {
-        throw std::invalid_argument("Unable to add DXEndpointStateChangeListener. The `listener` handle is invalid");
+        throw InvalidArgumentException("Unable to add DXEndpointStateChangeListener. The `listener` handle is invalid");
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_DXEndpoint_addStateChangeListener,
@@ -144,11 +144,11 @@ void removeStateChangeListener(
         &listener) {
 
     if (!endpoint) {
-        throw std::invalid_argument("Unable to remove DXEndpointStateChangeListener. The `endpoint` handle is invalid");
+        throw InvalidArgumentException("Unable to remove DXEndpointStateChangeListener. The `endpoint` handle is invalid");
     }
 
     if (!listener) {
-        throw std::invalid_argument("Unable to remove DXEndpointStateChangeListener. The `listener` handle is invalid");
+        throw InvalidArgumentException("Unable to remove DXEndpointStateChangeListener. The `listener` handle is invalid");
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_DXEndpoint_removeStateChangeListener,
@@ -158,7 +158,7 @@ void removeStateChangeListener(
 
 void * /* dxfg_feed_t* */ getFeed(/* dxfg_endpoint_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_getFeed`. The `endpoint` handle is invalid");
     }
 
@@ -169,7 +169,7 @@ void * /* dxfg_feed_t* */ getFeed(/* dxfg_endpoint_t * */ const JavaObjectHandle
 void * /* dxfg_publisher_t* */
 getPublisher(/* dxfg_endpoint_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_getPublisher`. The `endpoint` handle is invalid");
     }
 
@@ -180,7 +180,7 @@ getPublisher(/* dxfg_endpoint_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint> 
 /* dxfg_event_clazz_list_t* */ std::unordered_set<EventTypeEnum>
 getEventTypes(/* dxfg_endpoint_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint> &endpoint) {
     if (!endpoint) {
-        throw std::invalid_argument("Unable to retrieve event types. The `endpoint` handle is invalid");
+        throw InvalidArgumentException("Unable to retrieve event types. The `endpoint` handle is invalid");
     }
 
     std::unordered_set<EventTypeEnum> result{};
@@ -233,7 +233,7 @@ void /* int32_t */
 withRole(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint::Builder> &builder,
          /* dxfg_endpoint_role_t */ dxfcpp::DXEndpoint::Role role) {
     if (!builder) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_Builder_withRole`. The `builder` handle is invalid");
     }
 
@@ -246,7 +246,7 @@ void /* int32_t */
 withProperty(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint::Builder> &builder,
              std::string_view key, std::string_view value) {
     if (!builder) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_Builder_withProperty`. The `builder` handle is invalid");
     }
 
@@ -260,7 +260,7 @@ void /* int32_t */
 withProperties(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint::Builder> &builder,
                std::string_view filePath) {
     if (!builder) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_Builder_withProperties`. The `builder` handle is invalid");
     }
 
@@ -273,7 +273,7 @@ bool /* int32_t */
 supportsProperty(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint::Builder> &builder,
                  std::string_view key) {
     if (!builder) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_Builder_supportsProperty`. The `builder` handle is invalid");
     }
 
@@ -286,7 +286,7 @@ supportsProperty(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::
 void * /* dxfg_endpoint_t* */
 build(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint::Builder> &builder) {
     if (!builder) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXEndpoint_Builder_build`. The `builder` handle is invalid");
     }
 
@@ -299,7 +299,7 @@ build(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<dxfcpp::DXEndpoint:
 namespace StateChangeListener {
 JavaObjectHandle<dxfcpp::DXEndpointStateChangeListener> create(void *userFunc, void *userData) {
     if (!userFunc) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to create DXEndpointStateChangeListener. The `userFunc` parameter is nullptr");
     }
 

--- a/src/isolated/api/IsolatedDXFeed.cpp
+++ b/src/isolated/api/IsolatedDXFeed.cpp
@@ -15,7 +15,7 @@ namespace isolated::api::IsolatedDXFeed {
                                                         /* dxfg_symbol_t * */ const SymbolWrapper &symbol,
                                                         std::int64_t fromTime, std::int64_t toTime) {
     if (!feed) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeed_getTimeSeriesPromise`. The `feed` handle is invalid");
     }
 

--- a/src/isolated/api/IsolatedDXFeedSubscription.cpp
+++ b/src/isolated/api/IsolatedDXFeedSubscription.cpp
@@ -18,7 +18,7 @@ create(/* dxfg_event_clazz_t */ const EventTypeEnum &eventType) {
 JavaObjectHandle<DXFeedSubscription> /* dxfg_subscription_t* */
 create(/* dxfg_event_clazz_list_t * */ const std::unique_ptr<EventClassList> &eventClassList) {
     if (!eventClassList) {
-        throw std::invalid_argument("The eventClassList is nullptr");
+        throw InvalidArgumentException("The eventClassList is nullptr");
     }
 
     return JavaObjectHandle<DXFeedSubscription>(runGraalFunctionAndThrowIfNullptr(
@@ -27,7 +27,7 @@ create(/* dxfg_event_clazz_list_t * */ const std::unique_ptr<EventClassList> &ev
 
 bool /* int32_t */ isClosed(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_isClosed`. The `sub` handle is invalid");
     }
 
@@ -37,7 +37,7 @@ bool /* int32_t */ isClosed(/* dxfg_subscription_t * */ const JavaObjectHandle<D
 
 void /* int32_t */ close(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_close`. The `sub` handle is invalid");
     }
 
@@ -47,7 +47,7 @@ void /* int32_t */ close(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFe
 
 void /* int32_t */ clear(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_clear`. The `sub` handle is invalid");
     }
 
@@ -58,7 +58,7 @@ void /* int32_t */ clear(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFe
 std::vector<SymbolWrapper> /* dxfg_symbol_list* */
 getSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_getSymbols`. The `sub` handle is invalid");
     }
 
@@ -75,7 +75,7 @@ getSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription
 std::vector<SymbolWrapper> /* dxfg_symbol_list* */
 getDecoratedSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_getDecoratedSymbols`. The `sub` handle is invalid");
     }
 
@@ -92,12 +92,12 @@ getDecoratedSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSub
 void /* int32_t */ setSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub,
                               /* dxfg_symbol_list * */ void *symbols) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_setSymbols`. The `sub` handle is invalid");
     }
 
     if (!symbols) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_setSymbols`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_setSymbols`. The "
                                     "`symbols` is nullptr");
     }
 
@@ -109,12 +109,12 @@ void /* int32_t */ setSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle
 void /* int32_t */ addSymbol(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub,
                              /* dxfg_symbol_t * */ void *symbol) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_addSymbol`. The `sub` handle is invalid");
     }
 
     if (!symbol) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_addSymbol`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_addSymbol`. The "
                                     "`symbol` is nullptr");
     }
 
@@ -126,12 +126,12 @@ void /* int32_t */ addSymbol(/* dxfg_subscription_t * */ const JavaObjectHandle<
 void /* int32_t */ addSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub,
                               /* dxfg_symbol_list * */ void *symbols) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_addSymbols`. The `sub` handle is invalid");
     }
 
     if (!symbols) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_addSymbols`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_addSymbols`. The "
                                     "`symbols` is nullptr");
     }
 
@@ -143,12 +143,12 @@ void /* int32_t */ addSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle
 void /* int32_t */ removeSymbol(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub,
                                 /* dxfg_symbol_t * */ void *symbol) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_removeSymbol`. The `sub` handle is invalid");
     }
 
     if (!symbol) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_removeSymbol`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_removeSymbol`. The "
                                     "`symbol` is nullptr");
     }
 
@@ -160,12 +160,12 @@ void /* int32_t */ removeSymbol(/* dxfg_subscription_t * */ const JavaObjectHand
 void /* int32_t */ removeSymbols(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub,
                                  /* dxfg_symbol_list * */ void *symbols) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_removeSymbols`. The `sub` handle is invalid");
     }
 
     if (!symbols) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_removeSymbols`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_removeSymbols`. The "
                                     "`symbols` is nullptr");
     }
 
@@ -177,7 +177,7 @@ void /* int32_t */ removeSymbols(/* dxfg_subscription_t * */ const JavaObjectHan
 /* dxfg_time_period_t* */ JavaObjectHandle<TimePeriod>
 getAggregationPeriod(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_getAggregationPeriod`. The `sub` handle is invalid");
     }
 
@@ -188,12 +188,12 @@ getAggregationPeriod(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSu
 /* int32_t */ void setAggregationPeriod(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub,
                                         /* dxfg_time_period_t * */ const JavaObjectHandle<TimePeriod> &period) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_setAggregationPeriod`. The `sub` handle is invalid");
     }
 
     if (!period) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_setAggregationPeriod`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_setAggregationPeriod`. The "
                                     "`period` handle is invalid");
     }
 
@@ -206,12 +206,12 @@ void /* int32_t */
 addEventListener(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub,
                  /* dxfg_feed_event_listener_t * */ const JavaObjectHandle<dxfcpp::DXFeedEventListener> &listener) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_addEventListener`. The `sub` handle is invalid");
     }
 
     if (!listener) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_addEventListener`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_addEventListener`. The "
                                     "`listener` handle is invalid");
     }
 
@@ -225,12 +225,12 @@ void /* int32_t */ addChangeListener(
     /* dxfg_observable_subscription_change_listener_t * */ const JavaObjectHandle<ObservableSubscriptionChangeListener>
         &listener) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXFeedSubscription_addChangeListener`. The `sub` handle is invalid");
     }
 
     if (!listener) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_addChangeListener`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_addChangeListener`. The "
                                     "`listener` handle is invalid");
     }
 
@@ -244,12 +244,12 @@ void /* int32_t */ removeChangeListener(
     /* dxfg_observable_subscription_change_listener_t * */ const JavaObjectHandle<ObservableSubscriptionChangeListener>
         &listener) {
     if (!sub) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_removeChangeListener`. "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_removeChangeListener`. "
                                     "The `sub` handle is invalid");
     }
 
     if (!listener) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_removeChangeListener`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_removeChangeListener`. The "
                                     "`listener` handle is invalid");
     }
 
@@ -260,7 +260,7 @@ void /* int32_t */ removeChangeListener(
 
 std::int32_t getEventsBatchLimit(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub) {
     if (!sub) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_getEventsBatchLimit`. "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_getEventsBatchLimit`. "
                                     "The `sub` handle is invalid");
     }
 
@@ -271,7 +271,7 @@ std::int32_t getEventsBatchLimit(/* dxfg_subscription_t * */ const JavaObjectHan
 /* int32_t */ void setEventsBatchLimit(/* dxfg_subscription_t * */ const JavaObjectHandle<DXFeedSubscription> &sub,
                                        std::int32_t eventsBatchLimit) {
     if (!sub) {
-        throw std::invalid_argument("Unable to execute function `dxfg_DXFeedSubscription_setEventsBatchLimit`. "
+        throw InvalidArgumentException("Unable to execute function `dxfg_DXFeedSubscription_setEventsBatchLimit`. "
                                     "The `sub` handle is invalid");
     }
 
@@ -284,7 +284,7 @@ namespace DXFeedEventListener {
 JavaObjectHandle<dxfcpp::DXFeedEventListener> /* dxfg_feed_event_listener_t* */
 create(/* dxfg_feed_event_listener_function */ void *userFunc, void *userData) {
     if (!userFunc) {
-        throw std::invalid_argument("Unable to create DXFeedEventListener. The `userFunc` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create DXFeedEventListener. The `userFunc` parameter is nullptr");
     }
 
     return JavaObjectHandle<dxfcpp::DXFeedEventListener>(runGraalFunctionAndThrowIfNullptr(

--- a/src/isolated/api/IsolatedDXPublisher.cpp
+++ b/src/isolated/api/IsolatedDXPublisher.cpp
@@ -14,12 +14,12 @@ namespace isolated::api::IsolatedDXPublisher {
 void /* int32_t */ publishEvents(/* dxfg_publisher_t * */ const JavaObjectHandle<dxfcpp::DXPublisher> &publisher,
                                  /* dxfg_event_type_list * */ void *events) {
     if (!publisher) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXPublisher_publishEvents`. The `publisher` handle is invalid");
     }
 
     if (!events) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXPublisher_publishEvents`. The `events` is nullptr");
     }
 
@@ -32,7 +32,7 @@ JavaObjectHandle<DXPublisherObservableSubscription> /* dxfg_observable_subscript
 getSubscription(/* dxfg_publisher_t * */ const JavaObjectHandle<dxfcpp::DXPublisher> &publisher,
                 /* dxfg_event_clazz_t */ const EventTypeEnum &eventType) {
     if (!publisher) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_DXPublisher_getSubscription`. The `publisher` handle is invalid");
     }
 

--- a/src/isolated/api/IsolatedDXPublisherObservableSubscription.cpp
+++ b/src/isolated/api/IsolatedDXPublisherObservableSubscription.cpp
@@ -13,7 +13,7 @@ namespace isolated::api::IsolatedDXPublisherObservableSubscription {
 bool /* int32_t */
 isClosed(/* dxfg_observable_subscription_t * */ const JavaObjectHandle<DXPublisherObservableSubscription> &sub) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_ObservableSubscription_isClosed`. The `sub` handle is invalid");
     }
 
@@ -24,7 +24,7 @@ isClosed(/* dxfg_observable_subscription_t * */ const JavaObjectHandle<DXPublish
 std::unordered_set<EventTypeEnum> /* dxfg_event_clazz_list_t* */ getEventTypes(
     /* dxfg_observable_subscription_t * */ const JavaObjectHandle<DXPublisherObservableSubscription> &sub) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_ObservableSubscription_getEventTypes`. The `sub` handle is invalid");
     }
 
@@ -53,7 +53,7 @@ bool /* int32_t */ containsEventType(
     /* dxfg_observable_subscription_t * */ const JavaObjectHandle<DXPublisherObservableSubscription> &sub,
     /* dxfg_event_clazz_t */ const EventTypeEnum &eventType) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_ObservableSubscription_containsEventType`. The `sub` handle is invalid");
     }
 
@@ -67,12 +67,12 @@ void /* int32_t */ addChangeListener(
     /* dxfg_observable_subscription_change_listener_t * */ const JavaObjectHandle<ObservableSubscriptionChangeListener>
         &listener) {
     if (!sub) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_ObservableSubscription_addChangeListener`. The `sub` handle is invalid");
     }
 
     if (!listener) {
-        throw std::invalid_argument("Unable to execute function `dxfg_ObservableSubscription_addChangeListener`. The "
+        throw InvalidArgumentException("Unable to execute function `dxfg_ObservableSubscription_addChangeListener`. The "
                                     "`listener` handle is invalid");
     }
 
@@ -86,12 +86,12 @@ void /* int32_t */ removeChangeListener(
     /* dxfg_observable_subscription_change_listener_t * */ const JavaObjectHandle<ObservableSubscriptionChangeListener>
         &listener) {
     if (!sub) {
-        throw std::invalid_argument("Unable to execute function `dxfg_ObservableSubscription_removeChangeListener`. "
+        throw InvalidArgumentException("Unable to execute function `dxfg_ObservableSubscription_removeChangeListener`. "
                                     "The `sub` handle is invalid");
     }
 
     if (!listener) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_ObservableSubscription_removeChangeListener`. The "
             "`listener` handle is invalid");
     }

--- a/src/isolated/api/osub/IsolatedObservableSubscriptionChangeListener.cpp
+++ b/src/isolated/api/osub/IsolatedObservableSubscriptionChangeListener.cpp
@@ -16,17 +16,17 @@ create(/* dxfg_ObservableSubscriptionChangeListener_function_symbolsAdded */ voi
        /* dxfg_ObservableSubscriptionChangeListener_function_subscriptionClosed */ void *functionSubscriptionClosed,
        void *userData) {
     if (!functionSymbolsAdded) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to create ObservableSubscriptionChangeListener. The `functionSymbolsAdded` parameter is nullptr");
     }
 
     if (!functionSymbolsRemoved) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to create ObservableSubscriptionChangeListener. The `functionSymbolsRemoved` parameter is nullptr");
     }
 
     if (!functionSubscriptionClosed) {
-        throw std::invalid_argument("Unable to create ObservableSubscriptionChangeListener. The "
+        throw InvalidArgumentException("Unable to create ObservableSubscriptionChangeListener. The "
                                     "`functionSubscriptionClosed` parameter is nullptr");
     }
 

--- a/src/isolated/auth/IsolatedAuthToken.cpp
+++ b/src/isolated/auth/IsolatedAuthToken.cpp
@@ -65,7 +65,7 @@ createCustomToken(/* const char* */ const StringLikeWrapper &scheme,
 /* const char* */ std::string
 getHttpAuthorization(/* dxfg_auth_token_t* */ const JavaObjectHandle<AuthToken> &authToken) {
     if (!authToken) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_AuthToken_getHttpAuthorization`. The `authToken` handle is invalid");
     }
 
@@ -81,7 +81,7 @@ getHttpAuthorization(/* dxfg_auth_token_t* */ const JavaObjectHandle<AuthToken> 
 /// dxfg_AuthToken_getUser
 /* const char* */ std::string getUser(/* dxfg_auth_token_t* */ const JavaObjectHandle<AuthToken> &authToken) {
     if (!authToken) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_AuthToken_getUser`. The `authToken` handle is invalid");
     }
 
@@ -97,7 +97,7 @@ getHttpAuthorization(/* dxfg_auth_token_t* */ const JavaObjectHandle<AuthToken> 
 /// dxfg_AuthToken_getPassword
 /* const char* */ std::string getPassword(/* dxfg_auth_token_t* */ const JavaObjectHandle<AuthToken> &authToken) {
     if (!authToken) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_AuthToken_getPassword`. The `authToken` handle is invalid");
     }
 
@@ -113,7 +113,7 @@ getHttpAuthorization(/* dxfg_auth_token_t* */ const JavaObjectHandle<AuthToken> 
 /// dxfg_AuthToken_getScheme
 /* const char* */ std::string getScheme(/* dxfg_auth_token_t* */ const JavaObjectHandle<AuthToken> &authToken) {
     if (!authToken) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_AuthToken_getScheme`. The `authToken` handle is invalid");
     }
 
@@ -129,7 +129,7 @@ getHttpAuthorization(/* dxfg_auth_token_t* */ const JavaObjectHandle<AuthToken> 
 /// dxfg_AuthToken_getValue
 /* const char* */ std::string getValue(/* dxfg_auth_token_t* */ const JavaObjectHandle<AuthToken> &authToken) {
     if (!authToken) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_AuthToken_getValue`. The `authToken` handle is invalid");
     }
 

--- a/src/isolated/internal/IsolatedObject.cpp
+++ b/src/isolated/internal/IsolatedObject.cpp
@@ -15,7 +15,7 @@ namespace IsolatedObject {
 /// dxfg_Object_toString
 /* const char* */ std::string toString(/* dxfg_java_object_handler* */ void *object) {
     if (!object) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Object_toString`. The `object` is null");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Object_toString`. The `object` is null");
     }
 
     auto value =
@@ -30,11 +30,11 @@ namespace IsolatedObject {
 /// dxfg_Object_equals
 std::int32_t equals(/* dxfg_java_object_handler* */ void *object, /* dxfg_java_object_handler* */ void *other) {
     if (!object) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Object_equals`. The `object` is null");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Object_equals`. The `object` is null");
     }
 
     if (!other) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Object_equals`. The `other` is null");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Object_equals`. The `other` is null");
     }
 
     return runGraalFunctionAndThrowIfMinusMin(dxfg_Object_equals, static_cast<dxfg_java_object_handler *>(object),
@@ -44,7 +44,7 @@ std::int32_t equals(/* dxfg_java_object_handler* */ void *object, /* dxfg_java_o
 /// dxfg_Object_hashCode
 /* int32_t */ std::size_t hashCode(/* dxfg_java_object_handler* */ void *object) {
     if (!object) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Object_hashCode`. The `object` is null");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Object_hashCode`. The `object` is null");
     }
 
     return static_cast<std::size_t>(

--- a/src/isolated/internal/IsolatedString.cpp
+++ b/src/isolated/internal/IsolatedString.cpp
@@ -14,7 +14,7 @@ namespace IsolatedString {
 
 bool release(const char *string) {
     if (!string) {
-        throw std::invalid_argument("Unable to execute function `dxfg_String_release`. The `string` is nullptr");
+        throw InvalidArgumentException("Unable to execute function `dxfg_String_release`. The `string` is nullptr");
     }
 
     return runGraalFunctionAndThrowIfLessThanZero(dxfg_String_release, string) == 0;
@@ -30,7 +30,7 @@ namespace IsolatedStringList {
 
 bool release(/* dxfg_string_list* */ void *stringList) {
     if (!stringList) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_CList_String_release`. The `stringList` is nullptr");
     }
 

--- a/src/isolated/internal/IsolatedTimeFormat.cpp
+++ b/src/isolated/internal/IsolatedTimeFormat.cpp
@@ -24,7 +24,7 @@ namespace IsolatedTimeFormat {
 /* dxfg_time_format_t* */ JavaObjectHandle<dxfcpp::TimeFormat>
 withTimeZone(/* dxfg_time_format_t* */ const JavaObjectHandle<dxfcpp::TimeFormat> &timeFormat) {
     if (!timeFormat) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_TimeFormat_withTimeZone`. The `timeFormat` handle is invalid");
     }
 
@@ -35,7 +35,7 @@ withTimeZone(/* dxfg_time_format_t* */ const JavaObjectHandle<dxfcpp::TimeFormat
 /* dxfg_time_format_t* */ JavaObjectHandle<dxfcpp::TimeFormat>
 withMillis(/* dxfg_time_format_t* */ const JavaObjectHandle<dxfcpp::TimeFormat> &timeFormat) {
     if (!timeFormat) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_TimeFormat_withMillis`. The `timeFormat` handle is invalid");
     }
 
@@ -46,7 +46,7 @@ withMillis(/* dxfg_time_format_t* */ const JavaObjectHandle<dxfcpp::TimeFormat> 
 std::int64_t parse(/* dxfg_time_format_t* */ const JavaObjectHandle<dxfcpp::TimeFormat> &timeFormat,
                    std::string_view value) {
     if (!timeFormat) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_TimeFormat_parse`. The `timeFormat` handle is invalid");
     }
 
@@ -57,7 +57,7 @@ std::int64_t parse(/* dxfg_time_format_t* */ const JavaObjectHandle<dxfcpp::Time
 std::string format(/* dxfg_time_format_t* */ const JavaObjectHandle<dxfcpp::TimeFormat> &timeFormat,
                    std::int64_t value) {
     if (!timeFormat) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_TimeFormat_format`. The `timeFormat` handle is invalid");
     }
 

--- a/src/isolated/ipf/IsolatedInstrumentProfile.cpp
+++ b/src/isolated/ipf/IsolatedInstrumentProfile.cpp
@@ -20,7 +20,7 @@ namespace isolated::ipf::IsolatedInstrumentProfile {
 /* dxfg_instrument_profile_t* */ JavaObjectHandle<InstrumentProfile>
 create(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_new2`. The ip handle is invalid");
     }
 
@@ -31,7 +31,7 @@ create(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile
 // dxfg_InstrumentProfile_getType
 /* const char* */ std::string getType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getType`. The ip handle is invalid");
     }
 
@@ -46,7 +46,7 @@ create(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile
 /* int32_t */ void setType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                            const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setType`. The ip handle is invalid");
     }
 
@@ -58,7 +58,7 @@ create(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile
 /* const char* */ std::string
 getSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getSymbol`. The ip handle is invalid");
     }
 
@@ -73,7 +73,7 @@ getSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProf
 /* std::int32_t */ void setSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                   const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setSymbol`. The ip handle is invalid");
     }
 
@@ -85,7 +85,7 @@ getSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProf
 /* const char* */ std::string
 getDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getDescription`. The ip handle is invalid");
     }
 
@@ -100,7 +100,7 @@ getDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrumen
 /* std::int32_t */ void setDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                        const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setDescription`. The ip handle is invalid");
     }
 
@@ -112,7 +112,7 @@ getDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrumen
 /* const char* */ std::string
 getLocalSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getLocalSymbol`. The ip handle is invalid");
     }
 
@@ -127,7 +127,7 @@ getLocalSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrumen
 /* std::int32_t */ void setLocalSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                        const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setLocalSymbol`. The ip handle is invalid");
     }
 
@@ -139,7 +139,7 @@ getLocalSymbol(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrumen
 /* const char* */ std::string
 getLocalDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getLocalDescription`. The ip handle is invalid");
     }
 
@@ -155,7 +155,7 @@ getLocalDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Inst
 setLocalDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                     const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setLocalDescription`. The ip handle is invalid");
     }
 
@@ -167,7 +167,7 @@ setLocalDescription(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Inst
 /* const char* */ std::string
 getCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getCountry`. The ip handle is invalid");
     }
 
@@ -182,7 +182,7 @@ getCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPro
 /* std::int32_t */ void setCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                    const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setCountry`. The ip handle is invalid");
     }
 
@@ -193,7 +193,7 @@ getCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPro
 // dxfg_InstrumentProfile_getOPOL
 /* const char* */ std::string getOPOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getOPOL`. The ip handle is invalid");
     }
 
@@ -208,7 +208,7 @@ getCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPro
 /* std::int32_t */ void setOPOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                 const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setOPOL`. The ip handle is invalid");
     }
 
@@ -220,7 +220,7 @@ getCountry(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPro
 /* const char* */ std::string
 getExchangeData(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getExchangeData`. The ip handle is invalid");
     }
 
@@ -235,7 +235,7 @@ getExchangeData(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* std::int32_t */ void setExchangeData(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                         const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setExchangeData`. The ip handle is invalid");
     }
 
@@ -247,7 +247,7 @@ getExchangeData(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* const char* */ std::string
 getExchanges(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getExchanges`. The ip handle is invalid");
     }
 
@@ -262,7 +262,7 @@ getExchanges(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentP
 /* std::int32_t */ void setExchanges(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                      const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setExchanges`. The ip handle is invalid");
     }
 
@@ -274,7 +274,7 @@ getExchanges(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentP
 /* const char* */ std::string
 getCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getCurrency`. The ip handle is invalid");
     }
 
@@ -289,7 +289,7 @@ getCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPr
 /* std::int32_t */ void setCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                     const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setCurrency`. The ip handle is invalid");
     }
 
@@ -301,7 +301,7 @@ getCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPr
 /* const char* */ std::string
 getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getBaseCurrency`. The ip handle is invalid");
     }
 
@@ -316,7 +316,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* std::int32_t */ void setBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                         const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setBaseCurrency`. The ip handle is invalid");
     }
 
@@ -327,7 +327,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 // dxfg_InstrumentProfile_getCFI
 /* const char* */ std::string getCFI(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getCFI`. The ip handle is invalid");
     }
 
@@ -342,7 +342,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* std::int32_t */ void setCFI(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setCFI`. The ip handle is invalid");
     }
 
@@ -353,7 +353,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 // dxfg_InstrumentProfile_getISIN
 /* const char* */ std::string getISIN(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getISIN`. The ip handle is invalid");
     }
 
@@ -368,7 +368,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* std::int32_t */ void setISIN(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                 const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setISIN`. The ip handle is invalid");
     }
 
@@ -379,7 +379,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 // dxfg_InstrumentProfile_getSEDOL
 /* const char* */ std::string getSEDOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getSEDOL`. The ip handle is invalid");
     }
 
@@ -394,7 +394,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* std::int32_t */ void setSEDOL(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                  const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setSEDOL`. The ip handle is invalid");
     }
 
@@ -405,7 +405,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 // dxfg_InstrumentProfile_getCUSIP
 /* const char* */ std::string getCUSIP(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getCUSIP`. The ip handle is invalid");
     }
 
@@ -420,7 +420,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* std::int32_t */ void setCUSIP(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                  const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setCUSIP`. The ip handle is invalid");
     }
 
@@ -431,7 +431,7 @@ getBaseCurrency(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 // dxfg_InstrumentProfile_getICB
 std::int32_t getICB(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getICB`. The ip handle is invalid");
     }
 
@@ -443,7 +443,7 @@ std::int32_t getICB(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Inst
 /* std::int32_t */ void setICB(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                std::int32_t value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setICB`. The ip handle is invalid");
     }
 
@@ -454,7 +454,7 @@ std::int32_t getICB(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Inst
 // dxfg_InstrumentProfile_getSIC
 std::int32_t getSIC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getSIC`. The ip handle is invalid");
     }
 
@@ -466,7 +466,7 @@ std::int32_t getSIC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Inst
 /* std::int32_t */ void setSIC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                std::int32_t value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setSIC`. The ip handle is invalid");
     }
 
@@ -477,7 +477,7 @@ std::int32_t getSIC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Inst
 // dxfg_InstrumentProfile_getMultiplier
 double getMultiplier(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getMultiplier`. The ip handle is invalid");
     }
 
@@ -489,7 +489,7 @@ double getMultiplier(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Ins
 /* std::int32_t */ void setMultiplier(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                       double value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setMultiplier`. The ip handle is invalid");
     }
 
@@ -501,7 +501,7 @@ double getMultiplier(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Ins
 /* const char* */ std::string
 getProduct(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getProduct`. The ip handle is invalid");
     }
 
@@ -516,7 +516,7 @@ getProduct(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPro
 /* std::int32_t */ void setProduct(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                    const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setProduct`. The ip handle is invalid");
     }
 
@@ -528,7 +528,7 @@ getProduct(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentPro
 /* const char* */ std::string
 getUnderlying(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getUnderlying`. The ip handle is invalid");
     }
 
@@ -543,7 +543,7 @@ getUnderlying(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrument
 /* std::int32_t */ void setUnderlying(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                       const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setUnderlying`. The ip handle is invalid");
     }
 
@@ -554,7 +554,7 @@ getUnderlying(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrument
 // dxfg_InstrumentProfile_getSPC
 double getSPC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getSPC`. The ip handle is invalid");
     }
 
@@ -566,7 +566,7 @@ double getSPC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrument
 /* std::int32_t */ void setSPC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                double value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setSPC`. The ip handle is invalid");
     }
 
@@ -578,7 +578,7 @@ double getSPC(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrument
 /* const char* */ std::string
 getAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getAdditionalUnderlyings`. The ip handle is invalid");
     }
 
@@ -594,7 +594,7 @@ getAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle
 setAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                          const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setAdditionalUnderlyings`. The ip handle is invalid");
     }
 
@@ -605,7 +605,7 @@ setAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle
 // dxfg_InstrumentProfile_getMMY
 /* const char* */ std::string getMMY(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getMMY`. The ip handle is invalid");
     }
 
@@ -620,7 +620,7 @@ setAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle
 /* std::int32_t */ void setMMY(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setMMY`. The ip handle is invalid");
     }
 
@@ -631,7 +631,7 @@ setAdditionalUnderlyings(/* dxfg_instrument_profile_t* */ const JavaObjectHandle
 // dxfg_InstrumentProfile_getExpiration
 std::int32_t getExpiration(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getExpiration`. The ip handle is invalid");
     }
 
@@ -643,7 +643,7 @@ std::int32_t getExpiration(/* dxfg_instrument_profile_t* */ const JavaObjectHand
 /* std::int32_t */ void setExpiration(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                       std::int32_t value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setExpiration`. The ip handle is invalid");
     }
 
@@ -654,7 +654,7 @@ std::int32_t getExpiration(/* dxfg_instrument_profile_t* */ const JavaObjectHand
 // dxfg_InstrumentProfile_getLastTrade
 std::int32_t getLastTrade(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getLastTrade`. The ip handle is invalid");
     }
 
@@ -666,7 +666,7 @@ std::int32_t getLastTrade(/* dxfg_instrument_profile_t* */ const JavaObjectHandl
 /* std::int32_t */ void setLastTrade(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                      std::int32_t value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setLastTrade`. The ip handle is invalid");
     }
 
@@ -677,7 +677,7 @@ std::int32_t getLastTrade(/* dxfg_instrument_profile_t* */ const JavaObjectHandl
 // dxfg_InstrumentProfile_getStrike
 double getStrike(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getStrike`. The ip handle is invalid");
     }
 
@@ -689,7 +689,7 @@ double getStrike(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrum
 /* std::int32_t */ void setStrike(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                   double value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setStrike`. The ip handle is invalid");
     }
 
@@ -701,7 +701,7 @@ double getStrike(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrum
 /* const char* */ std::string
 getOptionType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getOptionType`. The ip handle is invalid");
     }
 
@@ -716,7 +716,7 @@ getOptionType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrument
 /* std::int32_t */ void setOptionType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                       const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setOptionType`. The ip handle is invalid");
     }
 
@@ -728,7 +728,7 @@ getOptionType(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrument
 /* const char* */ std::string
 getExpirationStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getExpirationStyle`. The ip handle is invalid");
     }
 
@@ -744,7 +744,7 @@ getExpirationStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instr
 setExpirationStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                    const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setExpirationStyle`. The ip handle is invalid");
     }
 
@@ -756,7 +756,7 @@ setExpirationStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instr
 /* const char* */ std::string
 getSettlementStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getSettlementStyle`. The ip handle is invalid");
     }
 
@@ -772,7 +772,7 @@ getSettlementStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instr
 setSettlementStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                    const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setSettlementStyle`. The ip handle is invalid");
     }
 
@@ -784,7 +784,7 @@ setSettlementStyle(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instr
 /* const char* */ std::string
 getPriceIncrements(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getPriceIncrements`. The ip handle is invalid");
     }
 
@@ -800,7 +800,7 @@ getPriceIncrements(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instr
 setPriceIncrements(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                    const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setPriceIncrements`. The ip handle is invalid");
     }
 
@@ -812,7 +812,7 @@ setPriceIncrements(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instr
 /* const char* */ std::string
 getTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getTradingHours`. The ip handle is invalid");
     }
 
@@ -827,7 +827,7 @@ getTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* std::int32_t */ void setTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                         const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setTradingHours`. The ip handle is invalid");
     }
 
@@ -839,7 +839,7 @@ getTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* const char* */ std::string getField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                        const StringLikeWrapper &name) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getField`. The ip handle is invalid");
     }
 
@@ -854,7 +854,7 @@ getTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 /* std::int32_t */ void setField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                  const StringLikeWrapper &name, const StringLikeWrapper &value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setField`. The ip handle is invalid");
     }
 
@@ -866,7 +866,7 @@ getTradingHours(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<Instrume
 double getNumericField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                        const StringLikeWrapper &name) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getNumericField`. The ip handle is invalid");
     }
 
@@ -878,7 +878,7 @@ double getNumericField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<I
 /* std::int32_t */ void setNumericField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                         const StringLikeWrapper &name, double value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setNumericField`. The ip handle is invalid");
     }
 
@@ -890,7 +890,7 @@ double getNumericField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<I
 std::int32_t getDateField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                           const StringLikeWrapper &name) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_getDateField`. The ip handle is invalid");
     }
 
@@ -902,7 +902,7 @@ std::int32_t getDateField(/* dxfg_instrument_profile_t* */ const JavaObjectHandl
 /* std::int32_t */ void setDateField(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip,
                                      const StringLikeWrapper &name, std::int32_t value) {
     if (!ip) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfile_setNumericField`. The ip handle is invalid");
     }
 
@@ -914,7 +914,7 @@ std::int32_t getDateField(/* dxfg_instrument_profile_t* */ const JavaObjectHandl
 /* dxfg_string_list* */ std::vector<std::string>
 getNonEmptyCustomFieldNames(/* dxfg_instrument_profile_t* */ const JavaObjectHandle<InstrumentProfile> &ip) {
     if (!ip) {
-        throw std::invalid_argument("Unable to execute function `dxfg_InstrumentProfile_getNonEmptyCustomFieldNames`. "
+        throw InvalidArgumentException("Unable to execute function `dxfg_InstrumentProfile_getNonEmptyCustomFieldNames`. "
                                     "The ip handle is invalid");
     }
 
@@ -941,7 +941,7 @@ getNonEmptyCustomFieldNames(/* dxfg_instrument_profile_t* */ const JavaObjectHan
 namespace isolated::ipf::IsolatedInstrumentProfileList {
 void release(/* dxfg_instrument_profile_list * */ void *list) {
     if (!list) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_CList_InstrumentProfile_wrapper_release`. The list is nullptr");
     }
 
@@ -951,7 +951,7 @@ void release(/* dxfg_instrument_profile_list * */ void *list) {
 
 void releaseWrapper(/* dxfg_instrument_profile_list * */ void *list) {
     if (!list) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_CList_InstrumentProfile_wrapper_release`. The list is nullptr");
     }
 

--- a/src/isolated/ipf/IsolatedInstrumentProfileReader.cpp
+++ b/src/isolated/ipf/IsolatedInstrumentProfileReader.cpp
@@ -19,7 +19,7 @@ namespace isolated::ipf::IsolatedInstrumentProfileReader {
 std::int64_t getLastModified(
     /* dxfg_instrument_profile_reader_t * */ const JavaObjectHandle<InstrumentProfileReader> &handle) {
     if (!handle) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfileReader_getLastModified`. The handle is invalid");
     }
 
@@ -30,7 +30,7 @@ std::int64_t getLastModified(
 bool wasComplete(
     /* dxfg_instrument_profile_reader_t * */ const JavaObjectHandle<InstrumentProfileReader> &handle) {
     if (!handle) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfileReader_wasComplete`. The handle is invalid");
     }
 
@@ -42,7 +42,7 @@ bool wasComplete(
 readFromFile(/* dxfg_instrument_profile_reader_t * */ const JavaObjectHandle<InstrumentProfileReader> &handle,
              const StringLikeWrapper &address) {
     if (!handle) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfileReader_readFromFile`. The handle is invalid");
     }
 
@@ -55,7 +55,7 @@ readFromFile(/* dxfg_instrument_profile_reader_t * */ const JavaObjectHandle<Ins
 readFromFile(/* dxfg_instrument_profile_reader_t * */ const JavaObjectHandle<InstrumentProfileReader> &handle,
              const StringLikeWrapper &address, const StringLikeWrapper &user, const StringLikeWrapper &password) {
     if (!handle) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfileReader_readFromFile`. The handle is invalid");
     }
 
@@ -69,12 +69,12 @@ readFromFile(/* dxfg_instrument_profile_reader_t * */ const JavaObjectHandle<Ins
 readFromFile(/* dxfg_instrument_profile_reader_t * */ const JavaObjectHandle<InstrumentProfileReader> &handle,
              const StringLikeWrapper &address, const JavaObjectHandle<AuthToken> &token) {
     if (!handle) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfileReader_readFromFile`. The handle is invalid");
     }
 
     if (!token) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_InstrumentProfileReader_readFromFile3`. The token is invalid");
     }
 

--- a/src/isolated/promise/IsolatedPromise.cpp
+++ b/src/isolated/promise/IsolatedPromise.cpp
@@ -13,7 +13,7 @@ namespace isolated::promise::IsolatedPromise {
 
 bool /* int32_t */ isDone(/* dxfg_promise_t * */ void *promise) {
     if (!promise) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Promise_isDone`. The `promise` is nullptr");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Promise_isDone`. The `promise` is nullptr");
     }
 
     return runGraalFunctionAndThrowIfLessThanZero(dxfg_Promise_isDone, static_cast<dxfg_promise_t *>(promise)) == 1;
@@ -21,7 +21,7 @@ bool /* int32_t */ isDone(/* dxfg_promise_t * */ void *promise) {
 
 bool /* int32_t */ hasResult(/* dxfg_promise_t * */ void *promise) {
     if (!promise) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Promise_hasResult`. The `promise` is nullptr");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Promise_hasResult`. The `promise` is nullptr");
     }
 
     return runGraalFunctionAndThrowIfLessThanZero(dxfg_Promise_hasResult, static_cast<dxfg_promise_t *>(promise)) == 1;
@@ -29,7 +29,7 @@ bool /* int32_t */ hasResult(/* dxfg_promise_t * */ void *promise) {
 
 bool /* int32_t */ hasException(/* dxfg_promise_t * */ void *promise) {
     if (!promise) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Promise_hasException`. The `promise` is nullptr");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Promise_hasException`. The `promise` is nullptr");
     }
 
     return runGraalFunctionAndThrowIfLessThanZero(dxfg_Promise_hasException, static_cast<dxfg_promise_t *>(promise)) ==
@@ -38,7 +38,7 @@ bool /* int32_t */ hasException(/* dxfg_promise_t * */ void *promise) {
 
 bool /* int32_t */ isCancelled(/* dxfg_promise_t * */ void *promise) {
     if (!promise) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Promise_isCancelled`. The `promise` is nullptr");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Promise_isCancelled`. The `promise` is nullptr");
     }
 
     return runGraalFunctionAndThrowIfLessThanZero(dxfg_Promise_isCancelled, static_cast<dxfg_promise_t *>(promise)) ==
@@ -47,7 +47,7 @@ bool /* int32_t */ isCancelled(/* dxfg_promise_t * */ void *promise) {
 
 std::shared_ptr<EventType> /* dxfg_event_type_t* */ getResult(/* dxfg_promise_event_t * */ void *promise) {
     if (!promise) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_Promise_EventType_getResult`. The `promise` is nullptr");
     }
 
@@ -64,7 +64,7 @@ std::shared_ptr<EventType> /* dxfg_event_type_t* */ getResult(/* dxfg_promise_ev
 std::vector<std::shared_ptr<EventType>> /* dxfg_event_type_list* */
 getResults(/* dxfg_promise_events_t * */ void *promise) {
     if (!promise) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_Promise_List_EventType_getResult`. The `promise` is nullptr");
     }
 
@@ -80,7 +80,7 @@ getResults(/* dxfg_promise_events_t * */ void *promise) {
 
 JavaException /* dxfg_exception_t* */ getException(/* dxfg_promise_t * */ void *promise) {
     if (!promise) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Promise_getException`. The `promise` is nullptr");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Promise_getException`. The `promise` is nullptr");
     }
 
     auto *graalException =
@@ -95,7 +95,7 @@ JavaException /* dxfg_exception_t* */ getException(/* dxfg_promise_t * */ void *
 
 void /* int32_t */ await(/* dxfg_promise_t * */ void *promise) {
     if (!promise) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Promise_await`. The `promise` is nullptr");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Promise_await`. The `promise` is nullptr");
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_Promise_await, static_cast<dxfg_promise_t *>(promise));
@@ -103,7 +103,7 @@ void /* int32_t */ await(/* dxfg_promise_t * */ void *promise) {
 
 void /* int32_t */ await(/* dxfg_promise_t * */ void *promise, std::int32_t timeoutInMilliseconds) {
     if (!promise) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Promise_await2`. The `promise` is nullptr");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Promise_await2`. The `promise` is nullptr");
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_Promise_await2, static_cast<dxfg_promise_t *>(promise),
@@ -112,7 +112,7 @@ void /* int32_t */ await(/* dxfg_promise_t * */ void *promise, std::int32_t time
 
 bool /* int32_t */ awaitWithoutException(/* dxfg_promise_t * */ void *promise, std::int32_t timeoutInMilliseconds) {
     if (!promise) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_Promise_awaitWithoutException`. The `promise` is nullptr");
     }
 
@@ -122,7 +122,7 @@ bool /* int32_t */ awaitWithoutException(/* dxfg_promise_t * */ void *promise, s
 
 void /* int32_t */ cancel(/* dxfg_promise_t * */ void *promise) {
     if (!promise) {
-        throw std::invalid_argument("Unable to execute function `dxfg_Promise_cancel`. The `promise` is nullptr");
+        throw InvalidArgumentException("Unable to execute function `dxfg_Promise_cancel`. The `promise` is nullptr");
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_Promise_cancel, static_cast<dxfg_promise_t *>(promise));

--- a/src/isolated/util/IsolatedTimePeriod.cpp
+++ b/src/isolated/util/IsolatedTimePeriod.cpp
@@ -27,7 +27,7 @@ namespace isolated::util::IsolatedTimePeriod {
 
 std::int64_t getTime(/* dxfg_time_period_t* */ const JavaObjectHandle<TimePeriod> &timePeriod) {
     if (!timePeriod) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_TimePeriod_getTime`. The `timePeriod` handle is invalid");
     }
 
@@ -37,7 +37,7 @@ std::int64_t getTime(/* dxfg_time_period_t* */ const JavaObjectHandle<TimePeriod
 
 std::int32_t getSeconds(/* dxfg_time_period_t* */ const JavaObjectHandle<TimePeriod> &timePeriod) {
     if (!timePeriod) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_TimePeriod_getSeconds`. The `timePeriod` handle is invalid");
     }
 
@@ -47,7 +47,7 @@ std::int32_t getSeconds(/* dxfg_time_period_t* */ const JavaObjectHandle<TimePer
 
 std::int64_t getNanos(/* dxfg_time_period_t* */ const JavaObjectHandle<TimePeriod> &timePeriod) {
     if (!timePeriod) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to execute function `dxfg_TimePeriod_getNanos`. The `timePeriod` handle is invalid");
     }
 

--- a/src/ondemand/OnDemandService.cpp
+++ b/src/ondemand/OnDemandService.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<OnDemandService> OnDemandService::getInstance(std::shared_ptr<DX
     std::shared_ptr<OnDemandService> onDemandService{new OnDemandService{}};
 
     if (!endpoint->handle_) {
-        throw std::invalid_argument("The endpoint's handle is invalid");
+        throw InvalidArgumentException("The endpoint's handle is invalid");
     }
 
     auto id = ApiContext::getInstance()->getManager<OnDemandServiceManager>()->registerEntity(onDemandService);

--- a/src/schedule/Day.cpp
+++ b/src/schedule/Day.cpp
@@ -14,7 +14,7 @@ Day::Day(void *handle) noexcept : handle_(handle) {
 
 Day::Ptr Day::create(void *handle) {
     if (!handle) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to create a Day object. The handle is nullptr");
     }
 

--- a/src/schedule/Schedule.cpp
+++ b/src/schedule/Schedule.cpp
@@ -13,7 +13,7 @@ Schedule::Schedule(void *handle) noexcept : handle_(handle) {
 
 Schedule::Ptr Schedule::create(void *handle) {
     if (!handle) {
-        throw std::invalid_argument("Unable to create a Schedule object. The handle is nullptr");
+        throw InvalidArgumentException("Unable to create a Schedule object. The handle is nullptr");
     }
 
     return std::shared_ptr<Schedule>(new Schedule(handle));
@@ -21,7 +21,7 @@ Schedule::Ptr Schedule::create(void *handle) {
 
 Schedule::Ptr Schedule::getInstance(std::shared_ptr<InstrumentProfile> profile) {
     if (!profile) {
-        throw std::invalid_argument("The profile is nullptr");
+        throw InvalidArgumentException("The profile is nullptr");
     }
 
     auto schedule = create(isolated::schedule::Schedule::getInstance(profile->handle_.get()));
@@ -35,7 +35,7 @@ Schedule::Ptr Schedule::getInstance(const std::string &scheduleDefinition) {
 
 Schedule::Ptr Schedule::getInstance(std::shared_ptr<InstrumentProfile> profile, const std::string &venue) {
     if (!profile) {
-        throw std::invalid_argument("The profile is nullptr");
+        throw InvalidArgumentException("The profile is nullptr");
     }
 
     auto schedule = create(isolated::schedule::Schedule::getInstance(profile->handle_.get(), venue));
@@ -45,7 +45,7 @@ Schedule::Ptr Schedule::getInstance(std::shared_ptr<InstrumentProfile> profile, 
 
 std::vector<std::string> Schedule::getTradingVenues(std::shared_ptr<InstrumentProfile> profile) {
     if (!profile) {
-        throw std::invalid_argument("The profile is nullptr");
+        throw InvalidArgumentException("The profile is nullptr");
     }
 
     auto result = isolated::schedule::Schedule::getTradingVenues(profile->handle_.get());

--- a/src/schedule/Session.cpp
+++ b/src/schedule/Session.cpp
@@ -13,7 +13,7 @@ Session::Session(void *handle) noexcept : handle_(handle) {
 
 Session::Ptr Session::create(void *handle) {
     if (!handle) {
-        throw std::invalid_argument(
+        throw InvalidArgumentException(
             "Unable to create a Session object. The handle is nullptr");
     }
 

--- a/src/symbols/StringSymbol.cpp
+++ b/src/symbols/StringSymbol.cpp
@@ -72,7 +72,7 @@ StringSymbol StringSymbol::fromGraal(void *graalNative) {
     }
 
     if (graalNative == nullptr) {
-        throw std::invalid_argument("Unable to create StringSymbol. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create StringSymbol. The `graalNative` parameter is nullptr");
     }
 
     auto *graalSymbol = static_cast<dxfg_string_symbol_t *>(graalNative);

--- a/src/symbols/SymbolWrapper.cpp
+++ b/src/symbols/SymbolWrapper.cpp
@@ -178,7 +178,7 @@ SymbolWrapper SymbolWrapper::fromGraal(void *graalNative) {
     }
 
     if (graalNative == nullptr) {
-        throw std::invalid_argument("Unable to create SymbolWrapper. The `graalNative` parameter is nullptr");
+        throw InvalidArgumentException("Unable to create SymbolWrapper. The `graalNative` parameter is nullptr");
     }
 
     switch (static_cast<dxfg_symbol_t *>(graalNative)->type) {
@@ -198,7 +198,7 @@ SymbolWrapper SymbolWrapper::fromGraal(void *graalNative) {
         return TimeSeriesSubscriptionSymbol::fromGraal(graalNative);
 
     default:
-        throw std::runtime_error(fmt::format("Unable to create SymbolWrapper. Unknown symbol type: {}",
+        throw RuntimeException(fmt::format("Unable to create SymbolWrapper. Unknown symbol type: {}",
                                              static_cast<int>(static_cast<dxfg_symbol_t *>(graalNative)->type)));
     }
 

--- a/tools/Tools/src/Connect/ConnectTool.hpp
+++ b/tools/Tools/src/Connect/ConnectTool.hpp
@@ -209,12 +209,8 @@ struct ConnectTool {
             sub->addSymbols(symbols);
             endpoint->connect(args.address);
             std::this_thread::sleep_for(std::chrono::days(365));
-        } catch (const JavaException &e) {
-            std::cerr << e.what() << '\n';
-            std::cerr << e.getStackTrace() << '\n';
-        } catch (const GraalException &e) {
-            std::cerr << e.what() << '\n';
-            std::cerr << e.getStackTrace() << '\n';
+        } catch (const RuntimeException &e) {
+            std::cerr << e << '\n';
         }
     }
 };

--- a/tools/Tools/src/Dump/DumpTool.hpp
+++ b/tools/Tools/src/Dump/DumpTool.hpp
@@ -133,6 +133,22 @@ struct DumpTool {
 
             System::setProperties(parsedProperties);
 
+            auto [parsedTypes, unknownTypes] = CmdArgsUtils::parseTypes(args.types.has_value() ? *args.types : "all");
+
+            if (!unknownTypes.empty()) {
+                auto unknown = elementsToString(unknownTypes.begin(), unknownTypes.end(), "", "");
+
+                throw InvalidArgumentException(
+                    fmt::format("There are unknown event types: {}!\n List of available event types: {}", unknown,
+                                enum_utils::getEventTypeEnumClassNamesList(", ")));
+            }
+
+            if (parsedTypes.empty()) {
+                throw InvalidArgumentException("The resulting list of types is empty!");
+            }
+
+            auto parsedSymbols = CmdArgsUtils::parseSymbols(args.symbols.has_value() ? *args.symbols : "all");
+
             auto inputEndpoint =
                 DXEndpoint::newBuilder()
                     ->withRole(DXEndpoint::Role::STREAM_FEED)
@@ -141,8 +157,7 @@ struct DumpTool {
                     ->withName(NAME + "Tool-Feed")
                     ->build();
 
-            auto sub = inputEndpoint->getFeed()->createSubscription(
-                !args.types.has_value() ? CmdArgsUtils::parseTypes("all") : CmdArgsUtils::parseTypes(*args.types));
+            auto sub = inputEndpoint->getFeed()->createSubscription(parsedTypes);
 
             if (!args.isQuite) {
                 sub->addEventListener([](auto &&events) {
@@ -173,8 +188,7 @@ struct DumpTool {
                 });
             }
 
-            sub->addSymbols(!args.symbols.has_value() ? CmdArgsUtils::parseSymbols("all")
-                                                      : CmdArgsUtils::parseSymbols(args.symbols.value()));
+            sub->addSymbols(parsedSymbols);
 
             inputEndpoint->connect(args.address);
             inputEndpoint->awaitNotConnected();

--- a/tools/Tools/src/Dump/DumpTool.hpp
+++ b/tools/Tools/src/Dump/DumpTool.hpp
@@ -184,12 +184,8 @@ struct DumpTool {
                 outputEndpoint.value()->awaitProcessed();
                 outputEndpoint.value()->closeAndAwaitTermination();
             }
-        } catch (const JavaException &e) {
-            std::cerr << e.what() << '\n';
-            std::cerr << e.getStackTrace() << '\n';
-        } catch (const GraalException &e) {
-            std::cerr << e.what() << '\n';
-            std::cerr << e.getStackTrace() << '\n';
+        } catch (const RuntimeException &e) {
+            std::cerr << e << '\n';
         }
     }
 };

--- a/tools/Tools/src/LatencyTest/LatencyTestTool.hpp
+++ b/tools/Tools/src/LatencyTest/LatencyTestTool.hpp
@@ -44,8 +44,8 @@ struct LatencyTest {
     [[nodiscard]] static std::string prepareHelp(std::size_t namePadding,
                                                  std::size_t nameFieldSize /* padding + name + padding */,
                                                  std::size_t) noexcept {
-        return fmt::format("{:{}}{:<{}}{:{}}{}\n", "", namePadding, getFullName(),
-                           nameFieldSize - 2 * namePadding, "", namePadding, SHORT_DESCRIPTION);
+        return fmt::format("{:{}}{:<{}}{:{}}{}\n", "", namePadding, getFullName(), nameFieldSize - 2 * namePadding, "",
+                           namePadding, SHORT_DESCRIPTION);
     }
 
     struct Diagnostic final {
@@ -320,16 +320,21 @@ struct LatencyTest {
                     intervalIsParsed = true;
                     index = parseResult.nextIndex;
                 } else {
-                    if (!forceStream && (forceStream = ForceStreamArg::parse(args, index).result)) {
-                        index++;
-                        continue;
+                    if (!forceStream) {
+                        forceStream = ForceStreamArg::parse(args, index).result;
+
+                        if (forceStream) {
+                            index++;
+                            continue;
+                        }
                     }
 
                     index++;
                 }
             }
 
-            return ParseResult<Args>::ok({parsedAddress.result, parsedTypes.result, parsedSymbols.result, properties, forceStream, interval.value_or(2)});
+            return ParseResult<Args>::ok({parsedAddress.result, parsedTypes.result, parsedSymbols.result, properties,
+                                          forceStream, interval.value_or(2)});
         }
     };
 

--- a/tools/Tools/src/LatencyTest/LatencyTestTool.hpp
+++ b/tools/Tools/src/LatencyTest/LatencyTestTool.hpp
@@ -340,7 +340,6 @@ struct LatencyTest {
 
     static void run(const Args &args) noexcept {
         try {
-
             using namespace std::literals;
 
             auto parsedProperties = CmdArgsUtils::parseProperties(args.properties);
@@ -368,12 +367,8 @@ struct LatencyTest {
             endpoint->connect(args.address);
             endpoint->awaitNotConnected();
             endpoint->closeAndAwaitTermination();
-        } catch (const JavaException &e) {
-            std::cerr << e.what() << '\n';
-            std::cerr << e.getStackTrace() << '\n';
-        } catch (const GraalException &e) {
-            std::cerr << e.what() << '\n';
-            std::cerr << e.getStackTrace() << '\n';
+        } catch (const RuntimeException &e) {
+            std::cerr << e << '\n';
         }
     }
 };

--- a/tools/Tools/src/PerfTest/PerfTestTool.hpp
+++ b/tools/Tools/src/PerfTest/PerfTestTool.hpp
@@ -271,12 +271,8 @@ struct PerfTestTool {
             endpoint->closeAndAwaitTermination();
 
             std::cout << hash << std::endl;
-        } catch (const JavaException &e) {
-            std::cerr << e.what() << '\n';
-            std::cerr << e.getStackTrace() << '\n';
-        } catch (const GraalException &e) {
-            std::cerr << e.what() << '\n';
-            std::cerr << e.getStackTrace() << '\n';
+        } catch (const RuntimeException &e) {
+            std::cerr << e << '\n';
         }
     }
 };

--- a/tools/Tools/src/PerfTest/PerfTestTool.hpp
+++ b/tools/Tools/src/PerfTest/PerfTestTool.hpp
@@ -133,8 +133,7 @@ struct PerfTestTool {
         }
 
       public:
-        static std::shared_ptr<Diagnostic> create(std::chrono::seconds measurementPeriod,
-                                                  bool showCpuUsageByCore) {
+        static std::shared_ptr<Diagnostic> create(std::chrono::seconds measurementPeriod, bool showCpuUsageByCore) {
             auto d = std::shared_ptr<Diagnostic>(new Diagnostic(showCpuUsageByCore));
 
             d->timer_ = Timer::schedule(
@@ -241,6 +240,22 @@ struct PerfTestTool {
 
             System::setProperties(parsedProperties);
 
+            auto [parsedTypes, unknownTypes] = CmdArgsUtils::parseTypes(args.types);
+
+            if (!unknownTypes.empty()) {
+                auto unknown = elementsToString(unknownTypes.begin(), unknownTypes.end(), "", "");
+
+                throw InvalidArgumentException(
+                    fmt::format("There are unknown event types: {}!\n List of available event types: {}", unknown,
+                                enum_utils::getEventTypeEnumClassNamesList(", ")));
+            }
+
+            if (parsedTypes.empty()) {
+                throw InvalidArgumentException("The resulting list of types is empty!");
+            }
+
+            auto parsedSymbols = CmdArgsUtils::parseSymbols(args.symbols);
+
             auto endpoint =
                 DXEndpoint::newBuilder()
                     ->withRole(args.forceStream ? DXEndpoint::Role::STREAM_FEED : DXEndpoint::Role::FEED)
@@ -249,7 +264,7 @@ struct PerfTestTool {
                     ->withName(NAME + "Tool-Feed")
                     ->build();
 
-            auto sub = endpoint->getFeed()->createSubscription(CmdArgsUtils::parseTypes(args.types));
+            auto sub = endpoint->getFeed()->createSubscription(parsedTypes);
             auto diagnostic = Diagnostic::create(2s, args.showCpuUsageByCore);
 
             std::atomic<std::size_t> hash{};
@@ -265,7 +280,7 @@ struct PerfTestTool {
                 });
             }
 
-            sub->addSymbols(CmdArgsUtils::parseSymbols(args.symbols));
+            sub->addSymbols(parsedSymbols);
             endpoint->connect(args.address);
             endpoint->awaitNotConnected();
             endpoint->closeAndAwaitTermination();

--- a/tools/Tools/src/main.cpp
+++ b/tools/Tools/src/main.cpp
@@ -83,12 +83,8 @@ int main(int argc, char *argv[]) {
 
                         std::cout << tools::Tools::getName() << "\n";
                         T::run(parseResult.result);
-                    } catch (const JavaException &e) {
-                        std::cerr << e.what() << '\n';
-                        std::cerr << e.getStackTrace() << '\n';
-                    } catch (const GraalException &e) {
-                        std::cerr << e.what() << '\n';
-                        std::cerr << e.getStackTrace() << '\n';
+                    } catch (const RuntimeException &e) {
+                        std::cerr << e << '\n';
                     }
                 },
                 tool);
@@ -97,12 +93,8 @@ int main(int argc, char *argv[]) {
         }
 
         std::cout << usage << "\n";
-    } catch (const JavaException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
-    } catch (const GraalException &e) {
-        std::cerr << e.what() << '\n';
-        std::cerr << e.getStackTrace() << '\n';
+    } catch (const RuntimeException &e) {
+        std::cerr << e << '\n';
     } catch (const std::runtime_error &e) {
         std::cerr << e.what() << '\n';
     } catch (...) {


### PR DESCRIPTION
Tools should report invalid event type.

For example, if the user specified an invalid type **11111**, then Tools should return the message:

**"There are unknown event types: 11111! List of available event types:**
**\<List of available event types\>**"
 
If for some reason the resulting list of types is empty, the following message should appear:
**"The resulting list of types is empty!"**