### PR TITLE
[MDAPI-127] [C++] Make statics initialization more lazy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ dist-*/
 CMakeSettings.json
 *.patch
 .vs/**
+.cache/**
+/Folder.DotSettings.user

--- a/include/dxfeed_graal_cpp_api/event/candle/CandleSession.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandleSession.hpp
@@ -34,7 +34,7 @@ DXFCPP_BEGIN_NAMESPACE
  * The key to use with these methods is available via CandleSession::ATTRIBUTE_KEY constant.
  * The value that this key shall be set to is equal to the corresponding CandleSession::toString()
  */
-struct DXFCPP_EXPORT CandleSession : public CandleSymbolAttribute {
+struct DXFCPP_EXPORT CandleSession final : CandleSymbolAttribute {
     /**
      * All trading sessions are used to build candles.
      */

--- a/include/dxfeed_graal_cpp_api/internal/Common.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/Common.hpp
@@ -285,7 +285,7 @@ constexpr static std::int32_t getYearMonthDayByDayId(std::int32_t dayId) {
     return yyyy >= 0 ? yyyymmdd : -yyyymmdd;
 }
 
-static std::int32_t getDayIdByYearMonthDay(std::int32_t year, std::int32_t month, std::int32_t day);
+std::int32_t getDayIdByYearMonthDay(std::int32_t year, std::int32_t month, std::int32_t day);
 
 } // namespace day_util
 
@@ -798,7 +798,7 @@ struct StringHash {
 
 namespace util {
 
-inline void throwInvalidChar(char c, const std::string &name);
+void throwInvalidChar(char c, const std::string &name);
 
 inline void checkChar(char c, std::uint32_t mask, const std::string &name) {
     if ((andOp(c, ~mask)) != 0) {

--- a/include/dxfeed_graal_cpp_api/internal/Isolate.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/Isolate.hpp
@@ -12,10 +12,8 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
 #include "Common.hpp"
 #include "utils/StringUtils.hpp"
 
-#include <concepts>
 #include <functional>
 #include <iostream>
-#include <memory>
 #include <mutex>
 #include <thread>
 #include <variant>
@@ -33,17 +31,16 @@ using ConstGraalIsolateThreadHandle = const void *;
 class Isolate final {
     struct IsolateThread final {
         GraalIsolateThreadHandle handle{};
-        bool isMain{};
         std::thread::id tid{};
         std::size_t idx{};
 
-        explicit IsolateThread(GraalIsolateThreadHandle handle = nullptr, bool isMain = false) noexcept
-            : handle{handle}, isMain{isMain}, tid{std::this_thread::get_id()} {
+        explicit IsolateThread(GraalIsolateThreadHandle handle = nullptr) noexcept
+            : handle{handle}, tid{std::this_thread::get_id()} {
             this->idx = Id<IsolateThread>::getNext().getValue();
 
             if constexpr (Debugger::traceIsolates) {
-                Debugger::trace("IsolateThread{" + dxfcpp::toString(handle) + ", isMain = " + dxfcpp::toString(isMain) +
-                                ", tid = " + dxfcpp::toString(tid) + ", idx = " + std::to_string(idx) + "}()");
+                Debugger::trace("IsolateThread{" + dxfcpp::toString(handle) + ", tid = " + dxfcpp::toString(tid) +
+                                ", idx = " + std::to_string(idx) + "}()");
             }
         }
 
@@ -62,41 +59,20 @@ class Isolate final {
                 Debugger::trace(toString() + "::~()");
             }
 
-            if (isMain) {
-                if constexpr (Debugger::traceIsolates) {
-                    Debugger::trace(toString() + "::~(): isMain => This is the main thread");
-                }
-
-                return;
-            }
-
-            detach();
+            // detach();
         }
 
         std::string toString() const {
-            return std::string("IsolateThread{") + dxfcpp::toString(handle) + ", isMain = " + dxfcpp::toString(isMain) +
-                   ", tid = " + dxfcpp::toString(tid) + ", idx = " + std::to_string(idx) + "}";
+            return std::string("IsolateThread{") + dxfcpp::toString(handle) + ", tid = " + dxfcpp::toString(tid) +
+                   ", idx = " + std::to_string(idx) + "}";
         }
     };
 
     mutable std::recursive_mutex mtx_{};
     ConstGraalIsolateThreadHandle handle_;
-    IsolateThread mainIsolateThread_;
     static thread_local IsolateThread currentIsolateThread_;
 
     Isolate() noexcept;
-
-    Isolate(GraalIsolateHandle handle, GraalIsolateThreadHandle mainIsolateThreadHandle) noexcept
-        : mtx_{}, handle_{handle}, mainIsolateThread_{mainIsolateThreadHandle, true} {
-
-        currentIsolateThread_.handle = mainIsolateThreadHandle;
-        currentIsolateThread_.isMain = true;
-
-        if constexpr (Debugger::traceIsolates) {
-            Debugger::trace("Isolate{" + dxfcpp::toString(handle) + ", main = " + mainIsolateThread_.toString() +
-                            ", current = " + currentIsolateThread_.toString() + "}()");
-        }
-    }
 
     CEntryPointErrorsEnum attach() noexcept;
 
@@ -269,8 +245,8 @@ class Isolate final {
     }
 
     std::string toString() const {
-        return std::string("Isolate{") + dxfcpp::toString(handle_) + ", main = " + mainIsolateThread_.toString() +
-               ", current = " + currentIsolateThread_.toString() + "}";
+        return std::string("Isolate{") + dxfcpp::toString(handle_) + ", current = " + currentIsolateThread_.toString() +
+               "}";
     }
 };
 

--- a/include/dxfeed_graal_cpp_api/internal/Isolate.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/Isolate.hpp
@@ -47,6 +47,12 @@ class Isolate final {
             }
         }
 
+        IsolateThread(const IsolateThread &) = delete;
+        IsolateThread(IsolateThread &&) = default;
+
+        IsolateThread &operator=(const IsolateThread &) = delete;
+        IsolateThread &operator=(IsolateThread &&) = default;
+
         CEntryPointErrorsEnum detach() noexcept;
 
         CEntryPointErrorsEnum detachAllThreadsAndTearDownIsolate() noexcept;

--- a/include/dxfeed_graal_cpp_api/internal/TimeFormat.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/TimeFormat.hpp
@@ -11,8 +11,11 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
 
 #include <cstdint>
 #include <string>
+#include <functional>
 
 DXFCPP_BEGIN_NAMESPACE
+
+struct StringLikeWrapper;
 
 /**
  * Utility class for parsing and formatting dates and times in ISO-compatible format.

--- a/include/dxfeed_graal_cpp_api/internal/TimeFormat.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/TimeFormat.hpp
@@ -38,9 +38,15 @@ struct DXFCPP_EXPORT TimeFormat {
     const static TimeFormat GMT;
 
   private:
-    JavaObjectHandle<TimeFormat> handle_;
+    mutable JavaObjectHandle<TimeFormat> handle_;
+    mutable std::mutex mtx_{};
+    mutable bool initialized_{};
+    std::function<JavaObjectHandle<TimeFormat>()> initializer_;
 
-    explicit TimeFormat(JavaObjectHandle<TimeFormat> &&handle);
+    //lazy c-tor
+    explicit TimeFormat(std::function<JavaObjectHandle<TimeFormat>()> &&initializer);
+
+    void init() const;
 
   public:
     virtual ~TimeFormat() noexcept = default;
@@ -49,6 +55,8 @@ struct DXFCPP_EXPORT TimeFormat {
     TimeFormat(TimeFormat &&) noexcept = delete;
     TimeFormat &operator=(const TimeFormat &) = delete;
     TimeFormat &operator=(const TimeFormat &&) noexcept = delete;
+
+    const JavaObjectHandle<TimeFormat> &getHandle() const;
 
     /**
      * Reads Date from String and returns timestamp.

--- a/include/dxfeed_graal_cpp_api/schedule/SessionFilter.hpp
+++ b/include/dxfeed_graal_cpp_api/schedule/SessionFilter.hpp
@@ -9,6 +9,8 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
 
 #include "SessionType.hpp"
 
+#include <mutex>
+
 DXFCPP_BEGIN_NAMESPACE
 
 enum class SessionFilterEnum : std::uint32_t {
@@ -40,9 +42,9 @@ enum class SessionFilterEnum : std::uint32_t {
  * some only non-trading, and some ignore type of session altogether.
  */
 struct DXFCPP_EXPORT SessionFilter {
-    friend struct Session;
-    friend struct Schedule;
-    friend struct Day;
+    // friend struct Session;
+    // friend struct Schedule;
+    // friend struct Day;
 
     /** Accepts any session - useful for pure schedule navigation. */
     static const SessionFilter ANY;
@@ -70,7 +72,8 @@ struct DXFCPP_EXPORT SessionFilter {
     /// Required trading flag, std::nullopt if not relevant.
     std::optional<bool> trading_;
 
-    JavaObjectHandle<SessionFilter> handle_;
+    mutable std::mutex mtx_{};
+    mutable JavaObjectHandle<SessionFilter> handle_{};
 
   public:
     SessionFilter() noexcept = default;
@@ -119,6 +122,8 @@ struct DXFCPP_EXPORT SessionFilter {
     const std::optional<bool> &getTrading() const & noexcept {
         return trading_;
     }
+
+    const JavaObjectHandle<SessionFilter>& getHandle() const&;
 };
 
 DXFCPP_END_NAMESPACE

--- a/include/dxfeed_graal_cpp_api/schedule/SessionFilter.hpp
+++ b/include/dxfeed_graal_cpp_api/schedule/SessionFilter.hpp
@@ -41,11 +41,7 @@ enum class SessionFilterEnum : std::uint32_t {
  * Different filters treat this distinction differently - some accept only trading sessions,
  * some only non-trading, and some ignore type of session altogether.
  */
-struct DXFCPP_EXPORT SessionFilter {
-    // friend struct Session;
-    // friend struct Schedule;
-    // friend struct Day;
-
+struct DXFCPP_EXPORT SessionFilter final {
     /** Accepts any session - useful for pure schedule navigation. */
     static const SessionFilter ANY;
     /** Accepts trading sessions only - those with <code>(Session::isTrading() == true)</code>. */
@@ -65,12 +61,12 @@ struct DXFCPP_EXPORT SessionFilter {
   protected:
     SessionFilterEnum code_{};
 
-    std::string name_;
+    std::string name_{};
 
     /// Required type, std::nullopt if not relevant.
-    std::optional<SessionType> type_;
+    std::optional<SessionType> type_{};
     /// Required trading flag, std::nullopt if not relevant.
-    std::optional<bool> trading_;
+    std::optional<bool> trading_{};
 
     mutable std::mutex mtx_{};
     mutable JavaObjectHandle<SessionFilter> handle_{};

--- a/include/dxfeed_graal_cpp_api/util/TimePeriod.hpp
+++ b/include/dxfeed_graal_cpp_api/util/TimePeriod.hpp
@@ -90,9 +90,16 @@ struct DXFCPP_EXPORT TimePeriod {
     TimePeriod &operator=(const TimePeriod &&) noexcept = delete;
 
   private:
-    JavaObjectHandle<TimePeriod> handle_;
+    mutable JavaObjectHandle<TimePeriod> handle_;
+    mutable std::mutex mtx_{};
+    mutable bool initialized_{};
+    std::function<JavaObjectHandle<TimePeriod>()> initializer_;
 
+    //lazy c-tor
+    explicit TimePeriod(std::function<JavaObjectHandle<TimePeriod>()> &&initializer);
     explicit TimePeriod(JavaObjectHandle<TimePeriod> &&handle);
+
+    void init() const;
 };
 
 DXFCPP_END_NAMESPACE

--- a/samples/cpp/OnDemandSample/src/main.cpp
+++ b/samples/cpp/OnDemandSample/src/main.cpp
@@ -16,7 +16,6 @@ int main(int /* argc */, char ** /* argv */) {
     using namespace std::literals;
 
     try {
-
         // get on-demand-only data feed
         auto onDemand = OnDemandService::getInstance();
         auto feed = onDemand->getEndpoint()->getFeed();

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -16,6 +16,4 @@ DXFCPP_BEGIN_NAMESPACE
 
 thread_local Isolate::IsolateThread Isolate::currentIsolateThread_{};
 
-auto IS = Isolate::getInstance().toString();
-
 DXFCPP_END_NAMESPACE

--- a/src/event/candle/CandleSession.cpp
+++ b/src/event/candle/CandleSession.cpp
@@ -17,9 +17,17 @@ const SessionType SessionType::AFTER_MARKET{SessionTypeEnum::AFTER_MARKET, "AFTE
 SessionFilter::SessionFilter(SessionFilterEnum code, std::string name, std::optional<SessionType> type,
                              std::optional<bool> trading) noexcept
     : code_{code}, name_{std::move(name)}, type_{type}, trading_{trading} {
+}
 
-    handle_ = JavaObjectHandle<SessionFilter>(
-        isolated::schedule::SessionFilter::getInstance(static_cast<std::uint32_t>(code)));
+const JavaObjectHandle<SessionFilter> &SessionFilter::getHandle() const & {
+    std::lock_guard<std::mutex> lock(mtx_);
+
+    if (!handle_) {
+        handle_ = JavaObjectHandle<SessionFilter>(
+            isolated::schedule::SessionFilter::getInstance(static_cast<std::uint32_t>(code_)));
+    }
+
+    return handle_;
 }
 
 const SessionFilter SessionFilter::ANY{SessionFilterEnum::ANY, "ANY", std::nullopt, std::nullopt};

--- a/src/internal/Common.cpp
+++ b/src/internal/Common.cpp
@@ -27,7 +27,7 @@ std::int32_t getDayIdByYearMonthDay(std::int32_t year, std::int32_t month, std::
 
 namespace util {
 
-inline void throwInvalidChar(char c, const std::string &name) {
+void throwInvalidChar(char c, const std::string &name) {
     throw InvalidArgumentException("Invalid " + name + ": " + encodeChar(c));
 }
 

--- a/src/internal/Isolate.cpp
+++ b/src/internal/Isolate.cpp
@@ -77,15 +77,12 @@ Isolate::Isolate() noexcept : mtx_{} {
             nullptr, &graalIsolateHandle, &graalIsolateThreadHandle)) == CEntryPointErrorsEnum::NO_ERROR) {
 
         handle_ = graalIsolateHandle;
-        mainIsolateThread_ = std::move(IsolateThread{graalIsolateThreadHandle, true});
-
         currentIsolateThread_.handle = graalIsolateThreadHandle;
-        currentIsolateThread_.isMain = true;
     }
 
     if constexpr (Debugger::traceIsolates) {
-        Debugger::trace("Isolate::Isolate() -> " + std::string("Isolate{") + dxfcpp::toString(handle_) + ", main = " +
-                        mainIsolateThread_.toString() + ", current = " + currentIsolateThread_.toString() + "}");
+        Debugger::trace("Isolate::Isolate() -> " + std::string("Isolate{") + dxfcpp::toString(handle_) +
+                        ", current = " + currentIsolateThread_.toString() + "}");
     }
 }
 
@@ -116,7 +113,6 @@ CEntryPointErrorsEnum Isolate::attach() noexcept {
         }
 
         currentIsolateThread_.handle = newIsolateThreadHandle;
-        currentIsolateThread_.isMain = mainIsolateThread_.handle == newIsolateThreadHandle;
 
         if constexpr (Debugger::traceIsolates) {
             Debugger::trace(toString() + "::attach(): Attached: " + currentIsolateThread_.toString());

--- a/src/internal/TimeFormat.cpp
+++ b/src/internal/TimeFormat.cpp
@@ -9,23 +9,52 @@
 
 DXFCPP_BEGIN_NAMESPACE
 
-const TimeFormat TimeFormat::DEFAULT(isolated::internal::IsolatedTimeFormat::getDefault());
-const TimeFormat
-    TimeFormat::DEFAULT_WITH_MILLIS(DEFAULT.handle_
-                                        ? isolated::internal::IsolatedTimeFormat::withMillis(DEFAULT.handle_)
-                                        : JavaObjectHandle<TimeFormat>{nullptr});
-const TimeFormat TimeFormat::DEFAULT_WITH_MILLIS_WITH_TIMEZONE(
-    DEFAULT_WITH_MILLIS.handle_ ? isolated::internal::IsolatedTimeFormat::withTimeZone(DEFAULT_WITH_MILLIS.handle_)
-                                : JavaObjectHandle<TimeFormat>{nullptr});
-const TimeFormat TimeFormat::GMT(isolated::internal::IsolatedTimeFormat::getGmt());
+const TimeFormat TimeFormat::DEFAULT([] {
+    return isolated::internal::IsolatedTimeFormat::getDefault();
+});
 
-TimeFormat::TimeFormat(JavaObjectHandle<TimeFormat> &&handle) : handle_(std::move(handle)){};
+const TimeFormat TimeFormat::DEFAULT_WITH_MILLIS([] {
+    return DEFAULT.getHandle() ? isolated::internal::IsolatedTimeFormat::withMillis(DEFAULT.getHandle())
+                               : JavaObjectHandle<TimeFormat>{nullptr};
+});
+
+const TimeFormat TimeFormat::DEFAULT_WITH_MILLIS_WITH_TIMEZONE([] {
+    return DEFAULT_WITH_MILLIS.getHandle()
+               ? isolated::internal::IsolatedTimeFormat::withTimeZone(DEFAULT_WITH_MILLIS.getHandle())
+               : JavaObjectHandle<TimeFormat>{nullptr};
+});
+
+const TimeFormat TimeFormat::GMT([] {
+    return isolated::internal::IsolatedTimeFormat::getGmt();
+});
+
+TimeFormat::TimeFormat(std::function<JavaObjectHandle<TimeFormat>()> &&initializer)
+    : initializer_(std::move(initializer)){};
+
+void TimeFormat::init() const {
+    std::lock_guard lock(mtx_);
+
+    if (!initialized_) {
+        handle_ = initializer_();
+        initialized_ = true;
+    }
+}
+
+const JavaObjectHandle<TimeFormat> &TimeFormat::getHandle() const {
+    init();
+
+    return handle_;
+}
 
 std::int64_t TimeFormat::parse(const StringLikeWrapper &value) const {
+    init();
+
     return isolated::internal::IsolatedTimeFormat::parse(handle_, value);
 }
 
 std::string TimeFormat::format(std::int64_t timestamp) const {
+    init();
+
     return isolated::internal::IsolatedTimeFormat::format(handle_, timestamp);
 }
 

--- a/src/internal/utils/CmdArgsUtils.cpp
+++ b/src/internal/utils/CmdArgsUtils.cpp
@@ -64,10 +64,6 @@ auto toUpper = [](auto&& s) {
            ranges::to<std::string>();
 };
 
-decltype(ranges::views::transform([](auto &&s) {
-    return toUpper(s);
-})) transformToUpper{};
-
 std::unordered_set<std::string> parseStringSymbols(const std::string &symbols) noexcept {
     auto trimmedSymbols = trimStr(symbols);
 

--- a/src/schedule/Day.cpp
+++ b/src/schedule/Day.cpp
@@ -14,8 +14,7 @@ Day::Day(void *handle) noexcept : handle_(handle) {
 
 Day::Ptr Day::create(void *handle) {
     if (!handle) {
-        throw InvalidArgumentException(
-            "Unable to create a Day object. The handle is nullptr");
+        throw InvalidArgumentException("Unable to create a Day object. The handle is nullptr");
     }
 
     return std::shared_ptr<Day>(new Day(handle));
@@ -138,13 +137,13 @@ std::vector<std::shared_ptr<Session>> Day::getSessions() const {
         return {};
     }
 
-    auto* graalSessionList = isolated::schedule::Day::getSessions(handle_.get());
+    auto *graalSessionList = isolated::schedule::Day::getSessions(handle_.get());
 
     if (!graalSessionList) {
         return {};
     }
 
-    auto* sessionList = dxfcpp::bit_cast<dxfg_session_list*>(graalSessionList);
+    auto *sessionList = dxfcpp::bit_cast<dxfg_session_list *>(graalSessionList);
     std::vector<std::shared_ptr<Session>> result;
 
     if (sessionList->size > 0 && sessionList->elements) {
@@ -155,8 +154,7 @@ std::vector<std::shared_ptr<Session>> Day::getSessions() const {
         }
     }
 
-    isolated::runGraalFunctionAndThrowIfLessThanZero(dxfg_SessionList_wrapper_release,
-                                              sessionList);
+    isolated::runGraalFunctionAndThrowIfLessThanZero(dxfg_SessionList_wrapper_release, sessionList);
 
     return result;
 }
@@ -170,35 +168,35 @@ std::shared_ptr<Session> Day::getSessionByTime(std::int64_t time) const noexcept
 }
 
 std::shared_ptr<Session> Day::getFirstSession(const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
-    return Session::create(isolated::schedule::Day::getFirstSession(handle_.get(), filter.handle_.get()));
+    return Session::create(isolated::schedule::Day::getFirstSession(handle_.get(), filter.getHandle().get()));
 }
 
 std::shared_ptr<Session> Day::getLastSession(const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
-    return Session::create(isolated::schedule::Day::getLastSession(handle_.get(), filter.handle_.get()));
+    return Session::create(isolated::schedule::Day::getLastSession(handle_.get(), filter.getHandle().get()));
 }
 
 std::shared_ptr<Session> Day::findFirstSession(const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
-    return Session::create(isolated::schedule::Day::findFirstSession(handle_.get(), filter.handle_.get()));
+    return Session::create(isolated::schedule::Day::findFirstSession(handle_.get(), filter.getHandle().get()));
 }
 
 std::shared_ptr<Session> Day::findLastSession(const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
-    return Session::create(isolated::schedule::Day::findLastSession(handle_.get(), filter.handle_.get()));
+    return Session::create(isolated::schedule::Day::findLastSession(handle_.get(), filter.getHandle().get()));
 }
 
 Day::Ptr Day::getPrevDay(const DayFilter &filter) const noexcept {

--- a/src/schedule/Schedule.cpp
+++ b/src/schedule/Schedule.cpp
@@ -94,21 +94,21 @@ Day::Ptr Schedule::getDayByYearMonthDay(std::int32_t yearMonthDay) const noexcep
 }
 
 Session::Ptr Schedule::getNearestSessionByTime(std::int64_t time, const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
     return Session::create(
-        isolated::schedule::Schedule::getNearestSessionByTime(handle_.get(), time, filter.handle_.get()));
+        isolated::schedule::Schedule::getNearestSessionByTime(handle_.get(), time, filter.getHandle().get()));
 }
 
 Session::Ptr Schedule::findNearestSessionByTime(std::int64_t time, const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
     return Session::create(
-        isolated::schedule::Schedule::findNearestSessionByTime(handle_.get(), time, filter.handle_.get()));
+        isolated::schedule::Schedule::findNearestSessionByTime(handle_.get(), time, filter.getHandle().get()));
 }
 
 std::string Schedule::getName() const noexcept {

--- a/src/schedule/Session.cpp
+++ b/src/schedule/Session.cpp
@@ -13,8 +13,7 @@ Session::Session(void *handle) noexcept : handle_(handle) {
 
 Session::Ptr Session::create(void *handle) {
     if (!handle) {
-        throw InvalidArgumentException(
-            "Unable to create a Session object. The handle is nullptr");
+        throw InvalidArgumentException("Unable to create a Session object. The handle is nullptr");
     }
 
     return std::shared_ptr<Session>(new Session(handle));
@@ -88,35 +87,35 @@ bool Session::containsTime(std::int64_t time) const noexcept {
 }
 
 Session::Ptr Session::getPrevSession(const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
-    return Session::create(isolated::schedule::Session::getPrevSession(handle_.get(), filter.handle_.get()));
+    return Session::create(isolated::schedule::Session::getPrevSession(handle_.get(), filter.getHandle().get()));
 }
 
 Session::Ptr Session::getNextSession(const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
-    return Session::create(isolated::schedule::Session::getNextSession(handle_.get(), filter.handle_.get()));
+    return Session::create(isolated::schedule::Session::getNextSession(handle_.get(), filter.getHandle().get()));
 }
 
 Session::Ptr Session::findPrevSession(const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
-    return Session::create(isolated::schedule::Session::findPrevSession(handle_.get(), filter.handle_.get()));
+    return Session::create(isolated::schedule::Session::findPrevSession(handle_.get(), filter.getHandle().get()));
 }
 
 Session::Ptr Session::findNextSession(const SessionFilter &filter) const noexcept {
-    if (!handle_ || !filter.handle_) {
+    if (!handle_ || !filter.getHandle()) {
         return {};
     }
 
-    return Session::create(isolated::schedule::Session::findNextSession(handle_.get(), filter.handle_.get()));
+    return Session::create(isolated::schedule::Session::findNextSession(handle_.get(), filter.getHandle().get()));
 }
 
 bool Session::operator==(const Session &other) const noexcept {

--- a/tests/api/DXEndpointTest.cpp
+++ b/tests/api/DXEndpointTest.cpp
@@ -141,19 +141,6 @@ TEST_CASE("dxfcpp::DXFeed::getInstance()") {
     dxfcpp::DXFeed::getInstance();
 }
 
-TEST_CASE("DXEndpoint::user") {
-    using namespace std::literals;
-
-    // dxfcpp::System::setProperty("log.file", "log.txt");
-
-    auto endpoint = dxfcpp::DXEndpoint::create(dxfcpp::DXEndpoint::Role::FEED);
-
-    endpoint->user("\xe2\x28\xa1");
-    endpoint->connect("123123123");
-
-    std::this_thread::sleep_for(std::chrono::seconds(5));
-}
-
 TEST_CASE("DXEndpoint::getFeed and getPublisher") {
     auto feed = DXEndpoint::getInstance()->getFeed();
     auto publisher = DXEndpoint::getInstance()->getPublisher();
@@ -180,8 +167,6 @@ TEST_CASE("Test DXEndpoint + multi-thread setProperty") {
     }
 
     endpoint->close();
-
-    std::cout << "!!!!!\n" << std::endl;
 }
 
 TEST_CASE("Test DXEndpoint + multi-thread setProperty v2") {
@@ -197,6 +182,4 @@ TEST_CASE("Test DXEndpoint + multi-thread setProperty v2") {
     std::this_thread::sleep_for(1s);
 
     endpoint->close();
-
-    std::cout << "!!!!!\n" << std::endl;
 }

--- a/tools/Tools/src/Args/Args.hpp
+++ b/tools/Tools/src/Args/Args.hpp
@@ -173,7 +173,13 @@ struct NamedUnsignedIntArg : NamedArg {
         if ((!A::SHORT_NAME.empty() && args[index] == "-" + A::SHORT_NAME) ||
             (!A::LONG_NAME.empty() && args[index] == "--" + A::LONG_NAME)) {
             try {
-                return ParseResult<std::optional<std::size_t>>::ok(std::stoull(args[index + 1]), index + 2);
+                auto res = std::stoull(args[index + 1]);
+
+                if (res >= std::numeric_limits<std::size_t>::max()) {
+                    return ParseResult<std::optional<std::size_t>>::ok(std::nullopt, index);
+                }
+
+                return ParseResult<std::optional<std::size_t>>::ok(static_cast<std::size_t>(res), index + 2);
             } catch (...) {
                 return ParseResult<std::optional<std::size_t>>::ok(std::nullopt, index);
             }


### PR DESCRIPTION
- Added `TimeFormat` and `TimePeriod` "lazy" c-tors.
- `IsolateThread` was made moveable-only.
- Got rid of warnings about `NamedUnsignedIntArg` on 32-bit architecture.
- Removed checks that `IsolateThread` is bound to the main thread. 
- Removed explicit `Isolate` initialization for the main thread.
- Initialization of `SessionFilter` handle made lazier.