### PR TITLE
Add support for retrieving indexed events from feed

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,4 @@
+* **\[MDAPI-77]\[C++]** Added support for retrieving indexed events from feed
 * **\[MDAPI-36]\[C++]** Implemented DXFeedTimeSeriesSubscription
     * Added `DXFeedTimeSeriesSubscription` class.
     * Added `DXFeed::createTimeSeriesSubscription` methods.

--- a/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXFeed.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXFeed.hpp
@@ -35,9 +35,11 @@ getLastEventIfSubscribed(/* dxfg_feed_t * */ const JavaObjectHandle<DXFeed> &fee
                          /* dxfg_event_clazz_t */ const EventTypeEnum &eventType,
                          /* dxfg_symbol_t * */ const SymbolWrapper &symbol);
 
+// dxfg_event_type_list* dxfg_DXFeed_getIndexedEventsIfSubscribed(graal_isolatethread_t *thread, dxfg_feed_t *feed, dxfg_event_clazz_t eventClazz, dxfg_symbol_t *symbol, const char *source);
+std::vector<std::shared_ptr<EventType>> getIndexedEventsIfSubscribed(const JavaObjectHandle<DXFeed> &feed, const EventTypeEnum &eventType, const SymbolWrapper &symbol,  const IndexedEventSource& source);
+
 /*
 
-dxfg_event_type_list*             dxfg_DXFeed_getIndexedEventsIfSubscribed(graal_isolatethread_t *thread, dxfg_feed_t *feed, dxfg_event_clazz_t eventClazz, dxfg_symbol_t *symbol, const char *source);
 dxfg_event_type_list*             dxfg_DXFeed_getTimeSeriesIfSubscribed(graal_isolatethread_t *thread, dxfg_feed_t *feed, dxfg_event_clazz_t eventClazz, dxfg_symbol_t *symbol, int64_t from_time, int64_t to_time);
 // use dxfg_EventType_new to create an empty structure so that java tries to free up memory when replacing subjects
 

--- a/src/api/DXFeed.cpp
+++ b/src/api/DXFeed.cpp
@@ -176,6 +176,12 @@ std::shared_ptr<EventType> DXFeed::getLastEventIfSubscribedImpl(const EventTypeE
     return isolated::api::IsolatedDXFeed::getLastEventIfSubscribed(handle_, eventType, symbol);
 }
 
+std::vector<std::shared_ptr<EventType>>
+DXFeed::getIndexedEventsIfSubscribedImpl(const EventTypeEnum &eventType, const SymbolWrapper &symbol,
+                                         const IndexedEventSource &source) const {
+    return isolated::api::IsolatedDXFeed::getIndexedEventsIfSubscribed(handle_, eventType, symbol, source);
+}
+
 JavaObjectHandle<DXFeedSubscription>
 DXFeed::createTimeSeriesSubscriptionHandleFromEventClassList(const std::unique_ptr<EventClassList> &list) {
     return isolated::api::IsolatedDXFeed::createTimeSeriesSubscription(handle_, list);

--- a/src/isolated/api/IsolatedDXFeed.cpp
+++ b/src/isolated/api/IsolatedDXFeed.cpp
@@ -70,6 +70,33 @@ getLastEventIfSubscribed(/* dxfg_feed_t * */ const JavaObjectHandle<DXFeed> &fee
     return EventMapper::fromGraal(u.get());
 }
 
+// dxfg_event_type_list* dxfg_DXFeed_getIndexedEventsIfSubscribed(graal_isolatethread_t *thread, dxfg_feed_t *feed,
+// dxfg_event_clazz_t eventClazz, dxfg_symbol_t *symbol, const char *source);
+std::vector<std::shared_ptr<EventType>> getIndexedEventsIfSubscribed(const JavaObjectHandle<DXFeed> &feed,
+                                                                     const EventTypeEnum &eventType,
+                                                                     const SymbolWrapper &symbol,
+                                                                     const IndexedEventSource &source) {
+    if (!feed) {
+        throw InvalidArgumentException(
+            "Unable to execute function `dxfg_DXFeed_getIndexedEventsIfSubscribed`. The `feed` handle is invalid");
+    }
+
+    auto graalSymbol = symbol.toGraalUnique();
+
+    const auto list = static_cast<void *>(runGraalFunctionAndThrowIfNullptr(
+        dxfg_DXFeed_getIndexedEventsIfSubscribed, static_cast<dxfg_feed_t *>(feed.get()),
+        static_cast<dxfg_event_clazz_t>(eventType.getId()), static_cast<dxfg_symbol_t *>(graalSymbol.get()),
+        source.toString().c_str()));
+
+    if (!list) {
+        return {};
+    }
+
+    auto u = event::IsolatedEventTypeList::toUnique(list);
+
+    return EventMapper::fromGraalList(u.get());
+}
+
 // dxfg_DXFeed_getLastEvent
 /* int32_t */ std::shared_ptr<EventType> getLastEvent(/* dxfg_feed_t * */ const JavaObjectHandle<DXFeed> &feed,
                                                       /* dxfg_event_type_t * */ const StringLikeWrapper &symbolName,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(DXFC_TEST_INCLUDE_DIRS ../include ../third_party/doctest-${DOCTEST_VERSION} 
 set(DXFC_TEST_SOURCES
         api/CandleSymbolTest.cpp
         api/DataIntegrityTest.cpp
+        api/DXFeedTest.cpp
         api/DXEndpointTest.cpp
         api/DXPublisherTest.cpp
         api/EventsTest.cpp

--- a/tests/api/DXFeedTest.cpp
+++ b/tests/api/DXFeedTest.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Devexperts LLC.
+// SPDX-License-Identifier: MPL-2.0
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include <dxfeed_graal_c_api/api.h>
+#include <dxfeed_graal_cpp_api/api.hpp>
+
+#include <doctest.h>
+
+using namespace dxfcpp;
+using namespace dxfcpp::literals;
+using namespace std::literals;
+
+TEST_CASE("DXFeed::getIndexedEventsIfSubscribed should return an empty vector when not subscribed to any events") {
+    auto events = DXFeed::getInstance()->getIndexedEventsIfSubscribed<Order>("AAPL", OrderSource::ntv);
+
+    REQUIRE(events.empty());
+}
+
+struct DXFeedTestFixture {
+    const char *symbol = "TEST";
+    DXEndpoint::Ptr endpoint{};
+    DXFeed::Ptr feed{};
+    DXPublisher::Ptr pub{};
+
+    DXFeedTestFixture() {
+        endpoint = DXEndpoint::newBuilder()
+                       ->withRole(DXEndpoint::Role::LOCAL_HUB)
+                       ->withProperty(DXEndpoint::DXFEED_WILDCARD_ENABLE_PROPERTY, "true")
+                       ->withProperty(DXEndpoint::DXENDPOINT_EVENT_TIME_PROPERTY, "true")
+                       ->withProperty(DXEndpoint::DXSCHEME_NANO_TIME_PROPERTY, "true")
+                       ->build();
+        feed = endpoint->getFeed();
+        pub = endpoint->getPublisher();
+    }
+
+    std::shared_ptr<Order> createOrder(std::int64_t index, const Side &side, double price, double size,
+                                       std::int32_t eventFlags) {
+        return std::make_shared<Order>(symbol)
+            ->withIndex(index)
+            .withOrderSide(side)
+            .withPrice(price)
+            .withSize(size)
+            .withEventFlags(eventFlags)
+            .sharedAs<Order>();
+    }
+
+    ~DXFeedTestFixture() {
+        endpoint->awaitProcessed();
+        endpoint->close();
+    }
+};
+
+TEST_CASE_FIXTURE(DXFeedTestFixture, "DXFeed::getIndexedEventsIfSubscribed should return events") {
+    auto o = createOrder(0, Side::BUY, 1, 1,
+                         static_cast<std::int32_t>((EventFlag::SNAPSHOT_BEGIN | EventFlag::SNAPSHOT_END).getMask()));
+
+    auto sub = feed->createSubscription(Order::TYPE);
+    sub->addSymbols(symbol);
+
+    pub->publishEvents(o);
+    auto events = feed->getIndexedEventsIfSubscribed<Order>(symbol, OrderSource::DEFAULT);
+
+    REQUIRE(events.size() == 1);
+}


### PR DESCRIPTION
Implemented `getIndexedEventsIfSubscribed` in DXFeed to retrieve indexed events from the local cache when subscribed. Added corresponding tests to validate behavior and updated release notes to reflect the enhancement.