### PR TITLE
[MDAPI-78][C++] Added support for retrieving time-series events from the feed

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,5 @@
 * **\[MDAPI-77]\[C++]** Added support for retrieving indexed events from feed
+* **\[MDAPI-78]\[C++]** Added support for retrieving time-series events from feed
 * **\[MDAPI-36]\[C++]** Implemented DXFeedTimeSeriesSubscription
     * Added `DXFeedTimeSeriesSubscription` class.
     * Added `DXFeed::createTimeSeriesSubscription` methods.

--- a/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXFeed.hpp
+++ b/include/dxfeed_graal_cpp_api/isolated/api/IsolatedDXFeed.hpp
@@ -38,13 +38,11 @@ getLastEventIfSubscribed(/* dxfg_feed_t * */ const JavaObjectHandle<DXFeed> &fee
 // dxfg_event_type_list* dxfg_DXFeed_getIndexedEventsIfSubscribed(graal_isolatethread_t *thread, dxfg_feed_t *feed, dxfg_event_clazz_t eventClazz, dxfg_symbol_t *symbol, const char *source);
 std::vector<std::shared_ptr<EventType>> getIndexedEventsIfSubscribed(const JavaObjectHandle<DXFeed> &feed, const EventTypeEnum &eventType, const SymbolWrapper &symbol,  const IndexedEventSource& source);
 
-/*
+// dxfg_event_type_list*  dxfg_DXFeed_getTimeSeriesIfSubscribed(graal_isolatethread_t *thread, dxfg_feed_t *feed, dxfg_event_clazz_t eventClazz, dxfg_symbol_t *symbol, int64_t from_time, int64_t to_time);
+std::vector<std::shared_ptr<EventType>> getTimeSeriesIfSubscribed(const JavaObjectHandle<DXFeed> &feed, const EventTypeEnum &eventType, const SymbolWrapper &symbol,  std::int64_t fromTime, std::int64_t toTime);
 
-dxfg_event_type_list*             dxfg_DXFeed_getTimeSeriesIfSubscribed(graal_isolatethread_t *thread, dxfg_feed_t *feed, dxfg_event_clazz_t eventClazz, dxfg_symbol_t *symbol, int64_t from_time, int64_t to_time);
+
 // use dxfg_EventType_new to create an empty structure so that java tries to free up memory when replacing subjects
-
-*/
-
 // dxfg_DXFeed_getLastEvent
 /* int32_t */ std::shared_ptr<EventType> getLastEvent(/* dxfg_feed_t * */ const JavaObjectHandle<DXFeed>& feed, /* dxfg_event_type_t * */ const StringLikeWrapper& symbolName, const EventTypeEnum& eventType);
 

--- a/src/api/DXFeed.cpp
+++ b/src/api/DXFeed.cpp
@@ -182,6 +182,13 @@ DXFeed::getIndexedEventsIfSubscribedImpl(const EventTypeEnum &eventType, const S
     return isolated::api::IsolatedDXFeed::getIndexedEventsIfSubscribed(handle_, eventType, symbol, source);
 }
 
+std::vector<std::shared_ptr<EventType>> DXFeed::getTimeSeriesIfSubscribedImpl(const EventTypeEnum &eventType,
+                                                                                    const SymbolWrapper &symbol,
+                                                                                    std::int64_t fromTime,
+                                                                                    std::int64_t toTime) const {
+    return isolated::api::IsolatedDXFeed::getTimeSeriesIfSubscribed(handle_, eventType, symbol, fromTime, toTime);
+}
+
 JavaObjectHandle<DXFeedSubscription>
 DXFeed::createTimeSeriesSubscriptionHandleFromEventClassList(const std::unique_ptr<EventClassList> &list) {
     return isolated::api::IsolatedDXFeed::createTimeSeriesSubscription(handle_, list);

--- a/src/isolated/api/IsolatedDXFeed.cpp
+++ b/src/isolated/api/IsolatedDXFeed.cpp
@@ -97,6 +97,29 @@ std::vector<std::shared_ptr<EventType>> getIndexedEventsIfSubscribed(const JavaO
     return EventMapper::fromGraalList(u.get());
 }
 
+// dxfg_event_type_list*  dxfg_DXFeed_getTimeSeriesIfSubscribed(graal_isolatethread_t *thread, dxfg_feed_t *feed,
+// dxfg_event_clazz_t eventClazz, dxfg_symbol_t *symbol, int64_t from_time, int64_t to_time);
+std::vector<std::shared_ptr<EventType>> getTimeSeriesIfSubscribed(const JavaObjectHandle<DXFeed> &feed,
+                                                                  const EventTypeEnum &eventType,
+                                                                  const SymbolWrapper &symbol, std::int64_t fromTime,
+                                                                  std::int64_t toTime) {
+    if (!feed) {
+        throw InvalidArgumentException(
+            "Unable to execute function `dxfg_DXFeed_getTimeSeriesIfSubscribed`. The `feed` handle is invalid");
+    }
+
+    auto graalSymbol = symbol.toGraalUnique();
+
+    const auto list = static_cast<void *>(
+        runGraalFunctionAndThrowIfNullptr(dxfg_DXFeed_getTimeSeriesIfSubscribed, static_cast<dxfg_feed_t *>(feed.get()),
+                                          static_cast<dxfg_event_clazz_t>(eventType.getId()),
+                                          static_cast<dxfg_symbol_t *>(graalSymbol.get()), fromTime, toTime));
+
+    auto u = event::IsolatedEventTypeList::toUnique(list);
+
+    return EventMapper::fromGraalList(u.get());
+}
+
 // dxfg_DXFeed_getLastEvent
 /* int32_t */ std::shared_ptr<EventType> getLastEvent(/* dxfg_feed_t * */ const JavaObjectHandle<DXFeed> &feed,
                                                       /* dxfg_event_type_t * */ const StringLikeWrapper &symbolName,


### PR DESCRIPTION
Introduced `getTimeSeriesIfSubscribed` functions to retrieve cached time-series events without making remote calls. Updated documentation, API, and test cases to reflect this addition. Ensured consistency in how event data is returned and processed.