### PR TITLE
Enable ASAN/UBSAN integration and refactor linking logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,4 +126,4 @@ jobs:
         if: ${{ ! cancelled() }}
         continue-on-error: true
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{matrix.buildType}} --parallel ${{matrix.config.cores}}
+        run: ctest -C ${{matrix.buildType}} --output-on-failure --parallel ${{matrix.config.cores}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
         sanitizers: [ NO_SAN, ASAN, UBSAN ]
 
     name: "${{ matrix.config.name }}-${{matrix.buildType}}-${{matrix.sanitizers}}"
+    if: ${{ !(contains(matrix.config.os, 'win') && contains(matrix.sanitizers, 'UBSAN')) }}
     runs-on: ${{ matrix.config.image }}
 
     steps:
@@ -126,4 +127,4 @@ jobs:
         if: ${{ ! cancelled() }}
         continue-on-error: true
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{matrix.buildType}} --extra-verbose --output-on-failure --parallel ${{matrix.config.cores}}
+        run: ctest -C ${{matrix.buildType}} --parallel ${{matrix.config.cores}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}}
           -DDXFCXX_BUILD_DOC=OFF
           -DDXFCXX_FEATURE_STACKTRACE=ON
+          -DDXFCXX_ENABLE_ASAN_UBSAN=ON
 
       - name: Configure CMake
         if: ${{ contains(matrix.config.os, 'linux') }}
@@ -98,6 +99,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}}
           -DDXFCXX_BUILD_DOC=OFF
           -DDXFCXX_FEATURE_STACKTRACE=ON
+          -DDXFCXX_ENABLE_ASAN_UBSAN=ON
 
       - name: Configure CMake
         if: ${{ contains(matrix.config.os, 'win') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,4 +126,4 @@ jobs:
         if: ${{ ! cancelled() }}
         continue-on-error: true
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{matrix.buildType}} --output-on-failure --parallel ${{matrix.config.cores}}
+        run: ctest -C ${{matrix.buildType}} --extra-verbose --output-on-failure --parallel ${{matrix.config.cores}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
             cc: 'clang'
             cxx: 'clang++'
         buildType: [ Release, Debug, RelWithDebInfo ]
+        sanitizers: [ NO_SAN, ASAN, UBSAN]
 
     name: "${{ matrix.config.name }}-${{matrix.buildType}}"
     runs-on: ${{ matrix.config.image }}
@@ -88,7 +89,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}}
           -DDXFCXX_BUILD_DOC=OFF
           -DDXFCXX_FEATURE_STACKTRACE=ON
-          -DDXFCXX_ENABLE_ASAN_UBSAN=ON
+          -DDXFCXX_ENABLE_${{matrix.sanitizers}}=ON
 
       - name: Configure CMake
         if: ${{ contains(matrix.config.os, 'linux') }}
@@ -99,7 +100,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}}
           -DDXFCXX_BUILD_DOC=OFF
           -DDXFCXX_FEATURE_STACKTRACE=ON
-          -DDXFCXX_ENABLE_ASAN_UBSAN=ON
+          -DDXFCXX_ENABLE_${{matrix.sanitizers}}=ON
 
       - name: Configure CMake
         if: ${{ contains(matrix.config.os, 'win') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,6 @@ jobs:
         sanitizers: [ NO_SAN, ASAN, UBSAN ]
 
     name: "${{ matrix.config.name }}-${{matrix.buildType}}-${{matrix.sanitizers}}"
-    if: ${{ !(contains(matrix.config.os, 'win') && contains(matrix.sanitizers, 'UBSAN')) }}
     runs-on: ${{ matrix.config.image }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,12 +43,12 @@ jobs:
             cores: 4
             cc: 'gcc-12'
             cxx: 'g++-12'
-#          - name: ubuntu-22.04-gcc-9
-#            image: ubuntu-22.04
-#            os: linux
-#            cores: 4
-#            cc: 'gcc-9'
-#            cxx: 'g++-9'
+          #          - name: ubuntu-22.04-gcc-9
+          #            image: ubuntu-22.04
+          #            os: linux
+          #            cores: 4
+          #            cc: 'gcc-9'
+          #            cxx: 'g++-9'
           - name: ubuntu-22.04-gcc-11
             image: ubuntu-22.04
             os: linux
@@ -63,9 +63,9 @@ jobs:
             cc: 'clang'
             cxx: 'clang++'
         buildType: [ Release, Debug, RelWithDebInfo ]
-        sanitizers: [ NO_SAN, ASAN, UBSAN]
+        sanitizers: [ NO_SAN, ASAN, UBSAN ]
 
-    name: "${{ matrix.config.name }}-${{matrix.buildType}}"
+    name: "${{ matrix.config.name }}-${{matrix.buildType}}-${{matrix.sanitizers}}"
     runs-on: ${{ matrix.config.image }}
 
     steps:
@@ -123,5 +123,6 @@ jobs:
           /p:CL_MPCount=${{matrix.config.cores}}
 
       - name: Test
+        if: ${{ ! cancelled() }}
         working-directory: ${{github.workspace}}/build
         run: ctest -C ${{matrix.buildType}} --extra-verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,5 +124,6 @@ jobs:
 
       - name: Test
         if: ${{ ! cancelled() }}
+        continue-on-error: true
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{matrix.buildType}} --extra-verbose
+        run: ctest -C ${{matrix.buildType}} --extra-verbose --output-on-failure --parallel ${{matrix.config.cores}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(DXFCXX_GRAAL_TARGET_CPU "unknown" CACHE STRING "")
 
 include(cmake/ParseAndDetectPlatforms.cmake)
 include(cmake/LinkStacktrace.cmake)
+include(cmake/LinkAsanUbsan.cmake)
 
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/graal-native-sdk-${DXFEED_GRAAL_NATIVE_SDK_VERSION}-${DXFCXX_GRAAL_TARGET_PLATFORM}/CMakeLists.txt")
     add_subdirectory(third_party/graal-native-sdk-${DXFEED_GRAAL_NATIVE_SDK_VERSION}-${DXFCXX_GRAAL_TARGET_PLATFORM})
@@ -538,9 +539,7 @@ if (DXFCXX_FEATURE_STACKTRACE)
 endif ()
 
 if (DXFCXX_ENABLE_ASAN_UBSAN)
-    target_compile_options(${PROJECT_NAME} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
-    target_link_options(${PROJECT_NAME} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
-    target_link_libraries(${PROJECT_NAME} PUBLIC asan ubsan)
+    LinkAsanUbsan(${PROJECT_NAME})
 endif ()
 
 add_custom_command(TARGET ${PROJECT_NAME}_static POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,8 @@ set(DXFEED_GRAAL_NATIVE_SDK_JFROG_BASE_URL "https://dxfeed.jfrog.io/artifactory/
 option(DXFCXX_USE_DXFG_STUB "Use dxFeed Graal SDK stub" OFF)
 set(DXFG_STUB_REPO "https://github.com/ttldtor/DxFeedGraalNativeSdkStub" CACHE STRING "")
 
-option(DXFCXX_ENABLE_ASAN_UBSAN "Enable address, UB sanitizers etc" OFF)
+option(DXFCXX_ENABLE_ASAN "Enable address, address sanitizer" OFF)
+option(DXFCXX_ENABLE_UBSAN "Enable address, UB sanitizer" OFF)
 option(DXFCXX_ENABLE_VS_ASAN "Enable VS address sanitizer" OFF)
 option(DXFCXX_USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 
@@ -538,8 +539,10 @@ if (DXFCXX_FEATURE_STACKTRACE)
     target_compile_definitions(${PROJECT_NAME}_static PUBLIC DXFCXX_FEATURE_STACKTRACE)
 endif ()
 
-if (DXFCXX_ENABLE_ASAN_UBSAN)
-    LinkAsanUbsan(${PROJECT_NAME})
+if (DXFCXX_ENABLE_ASAN)
+    LinkAsan(${PROJECT_NAME})
+elseif (DXFCXX_ENABLE_UBSAN)
+    LinkUbsan(${PROJECT_NAME})
 endif ()
 
 add_custom_command(TARGET ${PROJECT_NAME}_static POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ set(DXFG_STUB_REPO "https://github.com/ttldtor/DxFeedGraalNativeSdkStub" CACHE S
 
 option(DXFCXX_ENABLE_ASAN "Enable address, address sanitizer" OFF)
 option(DXFCXX_ENABLE_UBSAN "Enable address, UB sanitizer" OFF)
-option(DXFCXX_ENABLE_VS_ASAN "Enable VS address sanitizer" OFF)
 option(DXFCXX_USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 
 option(DXFCXX_FEATURE_STACKTRACE "Allow capturing stacktraces using boost::stacktrace" OFF)

--- a/cmake/LinkAsanUbsan.cmake
+++ b/cmake/LinkAsanUbsan.cmake
@@ -2,13 +2,27 @@
 # SPDX-License-Identifier: MPL-2.0
 
 function(LinkAsan targetName)
-    target_compile_options(${targetName} PRIVATE "-fsanitize=address")
-    target_link_options(${targetName} PRIVATE "-fsanitize=address")
-    #target_link_libraries(${targetName} PUBLIC asan ubsan)
+    if (WIN32)
+        target_compile_options(${targetName} PRIVATE "/fsanitize=address")
+        target_link_options(${targetName} PRIVATE "/fsanitize=address")
+
+        target_compile_definitions(${targetName}
+                PUBLIC
+                $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:
+                _DISABLE_VECTOR_ANNOTATION
+                _DISABLE_STRING_ANNOTATION
+                >
+        )
+    else ()
+        target_compile_options(${targetName} PRIVATE "-fsanitize=address")
+        target_link_options(${targetName} PRIVATE "-fsanitize=address")
+    endif ()
 endfunction()
 
 function(LinkUbsan targetName)
-    target_compile_options(${targetName} PRIVATE "-fsanitize=undefined")
-    target_link_options(${targetName} PRIVATE "-fsanitize=undefined")
-    #target_link_libraries(${targetName} PUBLIC asan ubsan)
+    if (WIN32)
+    else ()
+        target_compile_options(${targetName} PRIVATE "-fsanitize=undefined")
+        target_link_options(${targetName} PRIVATE "-fsanitize=undefined")
+    endif ()
 endfunction()

--- a/cmake/LinkAsanUbsan.cmake
+++ b/cmake/LinkAsanUbsan.cmake
@@ -1,8 +1,14 @@
 # Copyright (c) 2025 Devexperts LLC.
 # SPDX-License-Identifier: MPL-2.0
 
-function(LinkAsanUbsan targetName)
-    target_compile_options(${targetName} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
-    target_link_options(${targetName} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
-    target_link_libraries(${targetName} PUBLIC asan ubsan)
+function(LinkAsan targetName)
+    target_compile_options(${targetName} PRIVATE "-fsanitize=address")
+    target_link_options(${targetName} PRIVATE "-fsanitize=address")
+    #target_link_libraries(${targetName} PUBLIC asan ubsan)
+endfunction()
+
+function(LinkUbsan targetName)
+    target_compile_options(${targetName} PRIVATE "-fsanitize=undefined")
+    target_link_options(${targetName} PRIVATE "-fsanitize=undefined")
+    #target_link_libraries(${targetName} PUBLIC asan ubsan)
 endfunction()

--- a/cmake/LinkAsanUbsan.cmake
+++ b/cmake/LinkAsanUbsan.cmake
@@ -3,16 +3,21 @@
 
 function(LinkAsan targetName)
     if (WIN32)
-        target_compile_options(${targetName} PRIVATE "/fsanitize=address")
-        target_link_options(${targetName} PRIVATE "/fsanitize=address")
+        if (MINGW)
+            target_compile_options(${targetName} PRIVATE "-fsanitize=address")
+            target_link_options(${targetName} PRIVATE "-fsanitize=address")
+        else ()
+            target_compile_options(${targetName} PRIVATE "/fsanitize=address")
+            target_link_options(${targetName} PRIVATE "/fsanitize=address")
 
-        target_compile_definitions(${targetName}
-                PUBLIC
-                $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:
-                _DISABLE_VECTOR_ANNOTATION
-                _DISABLE_STRING_ANNOTATION
-                >
-        )
+            target_compile_definitions(${targetName}
+                    PUBLIC
+                    $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:
+                    _DISABLE_VECTOR_ANNOTATION
+                    _DISABLE_STRING_ANNOTATION
+                    >
+            )
+        endif ()
     else ()
         target_compile_options(${targetName} PRIVATE "-fsanitize=address")
         target_link_options(${targetName} PRIVATE "-fsanitize=address")
@@ -21,6 +26,10 @@ endfunction()
 
 function(LinkUbsan targetName)
     if (WIN32)
+        if (MINGW)
+            target_compile_options(${targetName} PRIVATE "-fsanitize=address")
+            target_link_options(${targetName} PRIVATE "-fsanitize=address")
+        endif ()
     else ()
         target_compile_options(${targetName} PRIVATE "-fsanitize=undefined")
         target_link_options(${targetName} PRIVATE "-fsanitize=undefined")

--- a/cmake/LinkAsanUbsan.cmake
+++ b/cmake/LinkAsanUbsan.cmake
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 function(LinkAsanUbsan targetName)
-    target_compile_options(${PROJECT_NAME} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
-    target_link_options(${PROJECT_NAME} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
-    target_link_libraries(${PROJECT_NAME} PUBLIC asan ubsan)
+    target_compile_options(${targetName} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
+    target_link_options(${targetName} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
+    target_link_libraries(${targetName} PUBLIC asan ubsan)
 endfunction()

--- a/cmake/LinkAsanUbsan.cmake
+++ b/cmake/LinkAsanUbsan.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Devexperts LLC.
+# SPDX-License-Identifier: MPL-2.0
+
+function(LinkAsanUbsan targetName)
+    target_compile_options(${PROJECT_NAME} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
+    target_link_options(${PROJECT_NAME} PRIVATE "-fsanitize=address" "-fsanitize=undefined")
+    target_link_libraries(${PROJECT_NAME} PUBLIC asan ubsan)
+endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,7 +45,7 @@ foreach (DXFC_TEST_SOURCE ${DXFC_TEST_SOURCES})
     set(DXFC_TEST_BASENAME dxFeedGraalCxxApi_${DXFC_TEST_BASENAME})
     #    message("${DXFC_TEST_BASENAME}: ${DXFC_TEST_SOURCE}")
 
-    add_executable(${DXFC_TEST_BASENAME} ${DXFC_TEST_SOURCE})
+    add_executable(${DXFC_TEST_BASENAME} ${DXFC_TEST_SOURCE} main.cpp)
     target_include_directories(${DXFC_TEST_BASENAME} PRIVATE ${DXFC_TEST_INCLUDE_DIRS})
     target_link_libraries(${DXFC_TEST_BASENAME} PRIVATE dxfcxx::static fmt::fmt-header-only)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,8 +53,10 @@ foreach (DXFC_TEST_SOURCE ${DXFC_TEST_SOURCES})
         LinkStacktrace(${DXFC_TEST_BASENAME})
     endif ()
 
-    if (DXFCXX_ENABLE_ASAN_UBSAN)
-        LinkAsanUbsan(${DXFC_TEST_BASENAME})
+    if (DXFCXX_ENABLE_ASAN)
+        LinkAsan(${DXFC_TEST_BASENAME})
+    elseif (DXFCXX_ENABLE_UBSAN)
+        LinkUbsan(${DXFC_TEST_BASENAME})
     endif ()
 
     set_target_properties(${DXFC_TEST_BASENAME} PROPERTIES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,10 @@ foreach (DXFC_TEST_SOURCE ${DXFC_TEST_SOURCES})
         LinkStacktrace(${DXFC_TEST_BASENAME})
     endif ()
 
+    if (DXFCXX_ENABLE_ASAN_UBSAN)
+        LinkAsanUbsan(${DXFC_TEST_BASENAME})
+    endif ()
+
     set_target_properties(${DXFC_TEST_BASENAME} PROPERTIES
             CXX_STANDARD 20
             CMAKE_C_STANDARD 11

--- a/tests/api/CandleSymbolTest.cpp
+++ b/tests/api/CandleSymbolTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/api/DXEndpointTest.cpp
+++ b/tests/api/DXEndpointTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/api/DXFeedTest.cpp
+++ b/tests/api/DXFeedTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <vector>

--- a/tests/api/DXPublisherTest.cpp
+++ b/tests/api/DXPublisherTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/api/DataIntegrityTest.cpp
+++ b/tests/api/DataIntegrityTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/api/EventsTest.cpp
+++ b/tests/api/EventsTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/api/MarketEventSymbolsTest.cpp
+++ b/tests/api/MarketEventSymbolsTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/api/OrderSourceTest.cpp
+++ b/tests/api/OrderSourceTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/event/EventsTest.cpp
+++ b/tests/event/EventsTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/exceptions/ExceptionsTest.cpp
+++ b/tests/exceptions/ExceptionsTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,118 @@
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest.h>
+
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include <dxfeed_graal_c_api/api.h>
+#include <dxfeed_graal_cpp_api/api.hpp>
+
+#ifdef WIN32
+void setSignalHandler() {
+}
+#else
+#    include <execinfo.h>
+#    include <signal.h>
+
+#    ifdef DXFCXX_FEATURE_STACKTRACE
+#        include <boost/stacktrace.hpp>
+#        include <fmt/format.h>
+
+inline std::string boostStackTraceToString(const boost::stacktrace::stacktrace &stacktrace) {
+    std::string result;
+
+    for (auto &&frame : stacktrace) {
+        result += "\tat ";
+        auto frameString = boost::stacktrace::to_string(frame);
+
+        if (frameString.empty()) {
+            result += "\n";
+
+            continue;
+        }
+
+        std::string what;
+        std::size_t whereStart = 0;
+
+        auto foundIn = frameString.find(" in ");
+
+        if (foundIn != std::string::npos) {
+            what = frameString.substr(0, foundIn);
+            whereStart = foundIn + 4;
+        } else {
+            auto foundAt = frameString.find(" at ");
+
+            if (foundAt != std::string::npos) {
+                what = frameString.substr(0, foundAt);
+                whereStart = foundIn + 4;
+            } else {
+                whereStart = frameString.size();
+            }
+        }
+
+        if (whereStart == frameString.size()) {
+            what = frameString;
+
+            result += what + "\n";
+
+            continue;
+        }
+
+        auto foundLastSep = frameString.find_last_of("\\/");
+        std::string where;
+
+        if (foundLastSep != std::string::npos && foundLastSep < frameString.size() - 1) {
+            where = frameString.substr(foundLastSep + 1);
+        } else {
+            where = frameString.substr(whereStart);
+        }
+
+        result += fmt::format("{}({})\n", what, where);
+    }
+
+    return result;
+}
+
+std::string getStackTrace() {
+    return boostStackTraceToString(boost::stacktrace::stacktrace());
+}
+#    else
+std::string getStackTrace() {
+    return "";
+}
+#    endif
+
+void sigSegvHandler(int) {
+    std::cerr << "SIGSEGV:\n" << getStackTrace() << std::endl;
+
+    exit(1);
+}
+
+void sigBusHandler(int) {
+    std::cerr << "SIGBUS:\n" << getStackTrace() << std::endl;
+
+    exit(1);
+}
+
+void setSignalHandler() {
+    signal(SIGSEGV, sigSegvHandler);
+    signal(SIGBUS, sigBusHandler);
+}
+#endif
+
+int main(int /*argc*/, char **/*argv*/) {
+    setSignalHandler();
+
+    doctest::Context context;
+
+    const int res = context.run(); // run queries, or run tests unless --no-run is specified
+
+    if (context.shouldExit()) // important - query flags (and --exit) rely on the user doing this
+        return res;           // propagate the result of the tests
+
+    context.clearFilters(); // removes all filters added up to this point
+
+    return res;
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,13 +1,13 @@
-#define DOCTEST_CONFIG_IMPLEMENT
-#include <doctest.h>
+// Copyright (c) 2025 Devexperts LLC.
+// SPDX-License-Identifier: MPL-2.0
 
-#include <string>
-#include <thread>
-#include <unordered_map>
-#include <vector>
+#define DOCTEST_CONFIG_IMPLEMENT
 
 #include <dxfeed_graal_c_api/api.h>
 #include <dxfeed_graal_cpp_api/api.hpp>
+
+#include <doctest.h>
+#include <string>
 
 #ifdef WIN32
 void setSignalHandler() {
@@ -102,7 +102,7 @@ void setSignalHandler() {
 }
 #endif
 
-int main(int /*argc*/, char **/*argv*/) {
+int main(int /*argc*/, char ** /*argv*/) {
     setSignalHandler();
 
     doctest::Context context;

--- a/tests/model/IndexedTxModelTest.cpp
+++ b/tests/model/IndexedTxModelTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/model/MarketDepthModelTest.cpp
+++ b/tests/model/MarketDepthModelTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include "dxfeed_graal_cpp_api/model/MarketDepthModel.hpp"
 
 #include <random>

--- a/tests/model/TimeSeriesTxModelTest.cpp
+++ b/tests/model/TimeSeriesTxModelTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 

--- a/tests/schedule/ScheduleTest.cpp
+++ b/tests/schedule/ScheduleTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/symbols/SymbolWrapperTest.cpp
+++ b/tests/symbols/SymbolWrapperTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/tests/system/SystemTest.cpp
+++ b/tests/system/SystemTest.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Devexperts LLC.
 // SPDX-License-Identifier: MPL-2.0
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #include <string>
 #include <thread>
 #include <unordered_map>


### PR DESCRIPTION
Added ASAN/UBSAN flags to the build configuration for enhanced runtime checks. Introduced a reusable `LinkAsanUbsan` function to centralize and simplify target linking. Updated relevant build and test scripts to use the new function.