### PR TITLE
[MDAPI-417]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,8 @@ option(DXFCXX_NODEFAULTLIB "Ignore libcmt/libcmtd/msvcrt/msvcrtd. Use if DXFCXX_
 
 option(DXFCXX_ENABLE_METRICS "Enable metrics collection" OFF)
 
-option(DXFCXX_USE_DXFEED_GRAAL_NATIVE_SDK_JFROG "" ON)
-set(DXFEED_GRAAL_NATIVE_SDK_JFROG_BASE_URL "https://dxfeed.jfrog.io/artifactory/maven-open/com/dxfeed/graal-native-sdk/" CACHE STRING "")
+option(DXFCXX_USE_DXFEED_GRAAL_NATIVE_SDK_GITHUB "" ON)
+set(DXFEED_GRAAL_NATIVE_SDK_JFROG_BASE_URL "https://github.com/dxFeed/dxfeed-graal-native-sdk/releases/download/" CACHE STRING "")
 option(DXFCXX_USE_DEBUG_DXFEED_GRAAL_NATIVE_SDK "" OFF)
 
 option(DXFCXX_USE_DXFG_STUB "Use dxFeed Graal SDK stub" OFF)
@@ -137,8 +137,8 @@ else ()
                         DOWNLOAD_NO_EXTRACT FALSE
                 )
             else ()
-                if (DXFCXX_USE_DXFEED_GRAAL_NATIVE_SDK_JFROG)
-                    set(DXFEED_GRAAL_NATIVE_SDK_URL "${DXFEED_GRAAL_NATIVE_SDK_JFROG_BASE_URL}${DXFEED_GRAAL_NATIVE_SDK_VERSION}/graal-native-sdk-${DXFEED_GRAAL_NATIVE_SDK_VERSION}")
+                if (DXFCXX_USE_DXFEED_GRAAL_NATIVE_SDK_GITHUB)
+                    set(DXFEED_GRAAL_NATIVE_SDK_URL "${DXFEED_GRAAL_NATIVE_SDK_JFROG_BASE_URL}v${DXFEED_GRAAL_NATIVE_SDK_VERSION}/graal-native-sdk-${DXFEED_GRAAL_NATIVE_SDK_VERSION}")
                 endif ()
 
                 if (DXFCXX_GRAAL_TARGET_PLATFORM STREQUAL "unknown-unknown")

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,5 @@
+* **\[MDAPI-417]** **\[BREAKING]** All methods of the `Order` class and its descendants whose names begin with "with" are made virtual.
+* The project now depends on the zip bundles of the dxFeed Graal Native SDK library, which are located in GitHub Releases.
 * **\[BREAKING]** Project build speed has been improved. The implementation of all non-template methods of non-template classes is now located in .cpp files.
 * Improved documentation. Classes are now divided into "modules". `Main Page - Topics - dxFeed Graal C++ API Modules.`
 

--- a/include/dxfeed_graal_cpp_api/event/market/AnalyticOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/AnalyticOrder.hpp
@@ -143,7 +143,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * midnight, January 1, 1970 UTC.
      * @return The current analytic order.
      */
-    AnalyticOrder &withEventTime(std::int64_t eventTime) noexcept;
+    AnalyticOrder &withEventTime(std::int64_t eventTime) noexcept override;
 
     // OrderBase methods
 
@@ -154,7 +154,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param source source of this event.
      * @return The current analytic order.
      */
-    AnalyticOrder &withSource(const OrderSource &source) noexcept;
+    AnalyticOrder &withSource(const OrderSource &source) noexcept override;
 
     /**
      * Changes transactional event flags and returns the current analytic order.
@@ -163,7 +163,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param eventFlags transactional event flags.
      * @return The current analytic order.
      */
-    AnalyticOrder &withEventFlags(std::int32_t eventFlags) noexcept;
+    AnalyticOrder &withEventFlags(std::int32_t eventFlags) noexcept override;
 
     /**
      * Changes transactional event flags and returns the current analytic order.
@@ -172,7 +172,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param eventFlags transactional event flags' mask.
      * @return The current analytic order.
      */
-    AnalyticOrder &withEventFlags(const EventFlagsMask &eventFlags) noexcept;
+    AnalyticOrder &withEventFlags(const EventFlagsMask &eventFlags) noexcept override;
 
     /**
      * Changes the unique per-symbol index of this analytic order and returns it. Note that this method also changes
@@ -182,7 +182,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param index unique per-symbol index of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withIndex(std::int64_t index) noexcept;
+    AnalyticOrder &withIndex(std::int64_t index) noexcept override;
 
     /**
      * Changes time of this analytic order and returns it.
@@ -191,7 +191,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param time time of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withTime(std::int64_t time) noexcept;
+    AnalyticOrder &withTime(std::int64_t time) noexcept override;
 
     /**
      * Changes microseconds and nanoseconds time part of this analytic order.
@@ -200,7 +200,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param timeNanoPart microseconds and nanoseconds time part of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withTimeNanoPart(std::int32_t timeNanoPart) noexcept;
+    AnalyticOrder &withTimeNanoPart(std::int32_t timeNanoPart) noexcept override;
 
     /**
      * Changes @ref OrderBase::getSequence() "sequence number" of this analytic order.
@@ -210,7 +210,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @return The current analytic order.
      * @see OrderBase::getSequence()
      */
-    AnalyticOrder &withSequence(std::int32_t sequence) noexcept;
+    AnalyticOrder &withSequence(std::int32_t sequence) noexcept override;
 
     /**
      * Changes time of this analytic order and returns it.
@@ -219,7 +219,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param timeNanos The time of this analytic order in nanoseconds.
      * @return The current analytic order.
      */
-    AnalyticOrder &withTimeNanos(std::int64_t timeNanos) noexcept;
+    AnalyticOrder &withTimeNanos(std::int64_t timeNanos) noexcept override;
 
     /**
      * Changes the action of this analytic order and returns it.
@@ -227,7 +227,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param action The side of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withAction(const OrderAction &action) noexcept;
+    AnalyticOrder &withAction(const OrderAction &action) noexcept override;
 
     /**
      * Changes time of the last action and returns the current analytic order.
@@ -235,7 +235,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param actionTime The last order action time.
      * @return The current analytic order.
      */
-    AnalyticOrder &withActionTime(std::int64_t actionTime) noexcept;
+    AnalyticOrder &withActionTime(std::int64_t actionTime) noexcept override;
 
     /**
      * Changes order ID.
@@ -244,7 +244,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param orderId The order ID.
      * @return The current analytic order.
      */
-    AnalyticOrder &withOrderId(std::int64_t orderId) noexcept;
+    AnalyticOrder &withOrderId(std::int64_t orderId) noexcept override;
 
     /**
      * Changes auxiliary order ID.
@@ -253,7 +253,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param auxOrderId The auxiliary order ID.
      * @return The current analytic order.
      */
-    AnalyticOrder &withAuxOrderId(std::int64_t auxOrderId) noexcept;
+    AnalyticOrder &withAuxOrderId(std::int64_t auxOrderId) noexcept override;
 
     /**
      * Changes price of this analytic order.
@@ -262,7 +262,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param price The price of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withPrice(double price) noexcept;
+    AnalyticOrder &withPrice(double price) noexcept override;
 
     /**
      * Changes size of this analytic order.
@@ -271,7 +271,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param size The size of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withSize(double size) noexcept;
+    AnalyticOrder &withSize(double size) noexcept override;
 
     /**
      * Changes executed size of this analytic order.
@@ -280,7 +280,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param executedSize The executed size of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withExecutedSize(double executedSize) noexcept;
+    AnalyticOrder &withExecutedSize(double executedSize) noexcept override;
 
     /**
      * Changes the number of individual orders in this aggregate order.
@@ -289,7 +289,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param count The number of individual orders in this aggregate order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withCount(std::int64_t count) noexcept;
+    AnalyticOrder &withCount(std::int64_t count) noexcept override;
 
     /**
      * Changes trade ID.
@@ -298,7 +298,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param tradeId The trade ID.
      * @return The current analytic order.
      */
-    AnalyticOrder &withTradeId(std::int64_t tradeId) noexcept;
+    AnalyticOrder &withTradeId(std::int64_t tradeId) noexcept override;
 
     /**
      * Changes trade price.
@@ -307,7 +307,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param tradePrice The trade price.
      * @return The current analytic order.
      */
-    AnalyticOrder &withTradePrice(double tradePrice) noexcept;
+    AnalyticOrder &withTradePrice(double tradePrice) noexcept override;
 
     /**
      * Changes trade size.
@@ -316,7 +316,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param tradeSize The trade size.
      * @return The current analytic order.
      */
-    AnalyticOrder &withTradeSize(double tradeSize) noexcept;
+    AnalyticOrder &withTradeSize(double tradeSize) noexcept override;
 
     /**
      * Changes exchange code of this analytic order.
@@ -325,7 +325,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param exchangeCode The exchange code of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withExchangeCode(char exchangeCode) noexcept;
+    AnalyticOrder &withExchangeCode(char exchangeCode) noexcept override;
 
     /**
      * Changes exchange code of this analytic order.
@@ -334,7 +334,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param exchangeCode The exchange code of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withExchangeCode(std::int16_t exchangeCode) noexcept;
+    AnalyticOrder &withExchangeCode(std::int16_t exchangeCode) noexcept override;
 
     /**
      * Changes side of this analytic order.
@@ -343,7 +343,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param side The side of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withOrderSide(const Side &side) noexcept;
+    AnalyticOrder &withOrderSide(const Side &side) noexcept override;
 
     /**
      * Changes the scope of this analytic order.
@@ -352,7 +352,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param scope The scope of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withScope(const Scope &scope) noexcept;
+    AnalyticOrder &withScope(const Scope &scope) noexcept override;
 
     // Order methods
 
@@ -363,7 +363,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @param marketMaker The market maker or another aggregate identifier of this analytic order.
      * @return The current analytic order.
      */
-    AnalyticOrder &withMarketMaker(const StringLike &marketMaker) noexcept;
+    AnalyticOrder &withMarketMaker(const StringLike &marketMaker) noexcept override;
 
     // AnalyticOrder methods
 

--- a/include/dxfeed_graal_cpp_api/event/market/Order.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Order.hpp
@@ -175,7 +175,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * midnight, January 1, 1970 UTC.
      * @return The current order.
      */
-    Order &withEventTime(std::int64_t eventTime) noexcept;
+    virtual Order &withEventTime(std::int64_t eventTime) noexcept;
 
     // OrderBase methods
 
@@ -186,7 +186,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param source source of this event.
      * @return The current order.
      */
-    Order &withSource(const OrderSource &source) noexcept;
+    virtual Order &withSource(const OrderSource &source) noexcept;
 
     /**
      * Changes transactional event flags and returns the current order.
@@ -195,7 +195,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param eventFlags transactional event flags.
      * @return The current order.
      */
-    Order &withEventFlags(std::int32_t eventFlags) noexcept;
+    virtual Order &withEventFlags(std::int32_t eventFlags) noexcept;
 
     /**
      * Changes transactional event flags and returns the current order.
@@ -204,7 +204,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param eventFlags transactional event flags' mask.
      * @return The current order.
      */
-    Order &withEventFlags(const EventFlagsMask &eventFlags) noexcept;
+    virtual Order &withEventFlags(const EventFlagsMask &eventFlags) noexcept;
 
     /**
      * Changes the unique per-symbol index of this order and returns it. Note that this method also changes
@@ -214,7 +214,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param index unique per-symbol index of this order.
      * @return The current order.
      */
-    Order &withIndex(std::int64_t index) noexcept;
+    virtual Order &withIndex(std::int64_t index) noexcept;
 
     /**
      * Changes time of this order and returns it.
@@ -223,7 +223,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param time time of this order.
      * @return The current order.
      */
-    Order &withTime(std::int64_t time) noexcept;
+    virtual Order &withTime(std::int64_t time) noexcept;
 
     /**
      * Changes microseconds and nanoseconds time part of this order.
@@ -232,7 +232,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param timeNanoPart microseconds and nanoseconds time part of this order.
      * @return The current order.
      */
-    Order &withTimeNanoPart(std::int32_t timeNanoPart) noexcept;
+    virtual Order &withTimeNanoPart(std::int32_t timeNanoPart) noexcept;
 
     /**
      * Changes @ref OrderBase::getSequence() "sequence number" of this order.
@@ -242,7 +242,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @return The current order.
      * @see OrderBase::getSequence()
      */
-    Order &withSequence(std::int32_t sequence) noexcept;
+    virtual Order &withSequence(std::int32_t sequence) noexcept;
 
     /**
      * Changes time of this order and returns it.
@@ -251,7 +251,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param timeNanos The time of this order in nanoseconds.
      * @return The current order.
      */
-    Order &withTimeNanos(std::int64_t timeNanos) noexcept;
+    virtual Order &withTimeNanos(std::int64_t timeNanos) noexcept;
 
     /**
      * Changes the action of this order and returns it.
@@ -259,7 +259,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param action The side of this order.
      * @return The current order.
      */
-    Order &withAction(const OrderAction &action) noexcept;
+    virtual Order &withAction(const OrderAction &action) noexcept;
 
     /**
      * Changes time of the last action and returns the current order.
@@ -267,7 +267,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param actionTime The last order action time.
      * @return The current order.
      */
-    Order &withActionTime(std::int64_t actionTime) noexcept;
+    virtual Order &withActionTime(std::int64_t actionTime) noexcept;
 
     /**
      * Changes order ID.
@@ -276,7 +276,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param orderId The order ID.
      * @return The current order.
      */
-    Order &withOrderId(std::int64_t orderId) noexcept;
+    virtual Order &withOrderId(std::int64_t orderId) noexcept;
 
     /**
      * Changes auxiliary order ID.
@@ -285,7 +285,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param auxOrderId The auxiliary order ID.
      * @return The current order.
      */
-    Order &withAuxOrderId(std::int64_t auxOrderId) noexcept;
+    virtual Order &withAuxOrderId(std::int64_t auxOrderId) noexcept;
 
     /**
      * Changes price of this order.
@@ -294,7 +294,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param price The price of this order.
      * @return The current order.
      */
-    Order &withPrice(double price) noexcept;
+    virtual Order &withPrice(double price) noexcept;
 
     /**
      * Changes size of this order.
@@ -303,7 +303,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param size The size of this order.
      * @return The current order.
      */
-    Order &withSize(double size) noexcept;
+    virtual Order &withSize(double size) noexcept;
 
     /**
      * Changes executed size of this order.
@@ -312,7 +312,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param executedSize The executed size of this order.
      * @return The current order.
      */
-    Order &withExecutedSize(double executedSize) noexcept;
+    virtual Order &withExecutedSize(double executedSize) noexcept;
 
     /**
      * Changes the number of individual orders in this aggregate order.
@@ -321,7 +321,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param count The number of individual orders in this aggregate order.
      * @return The current order.
      */
-    Order &withCount(std::int64_t count) noexcept;
+    virtual Order &withCount(std::int64_t count) noexcept;
 
     /**
      * Changes trade ID.
@@ -330,7 +330,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param tradeId The trade ID.
      * @return The current order.
      */
-    Order &withTradeId(std::int64_t tradeId) noexcept;
+    virtual Order &withTradeId(std::int64_t tradeId) noexcept;
 
     /**
      * Changes trade price.
@@ -339,7 +339,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param tradePrice The trade price.
      * @return The current order.
      */
-    Order &withTradePrice(double tradePrice) noexcept;
+    virtual Order &withTradePrice(double tradePrice) noexcept;
 
     /**
      * Changes trade size.
@@ -348,7 +348,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param tradeSize The trade size.
      * @return The current order.
      */
-    Order &withTradeSize(double tradeSize) noexcept;
+    virtual Order &withTradeSize(double tradeSize) noexcept;
 
     /**
      * Changes exchange code of this order.
@@ -357,7 +357,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param exchangeCode The exchange code of this order.
      * @return The current order.
      */
-    Order &withExchangeCode(char exchangeCode) noexcept;
+    virtual Order &withExchangeCode(char exchangeCode) noexcept;
 
     /**
      * Changes exchange code of this order.
@@ -366,7 +366,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param exchangeCode The exchange code of this order.
      * @return The current order.
      */
-    Order &withExchangeCode(std::int16_t exchangeCode) noexcept;
+    virtual Order &withExchangeCode(std::int16_t exchangeCode) noexcept;
 
     /**
      * Changes side of this order.
@@ -375,7 +375,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param side The side of this order.
      * @return The current order.
      */
-    Order &withOrderSide(const Side &side) noexcept;
+    virtual Order &withOrderSide(const Side &side) noexcept;
 
     /**
      * Changes scope of this order.
@@ -384,7 +384,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param scope The scope of this order.
      * @return The current order.
      */
-    Order &withScope(const Scope &scope) noexcept;
+    virtual Order &withScope(const Scope &scope) noexcept;
 
     // Order methods
 
@@ -419,7 +419,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @param marketMaker The market maker or the other aggregate identifier of this order.
      * @return The current order.
      */
-    Order &withMarketMaker(const StringLike &marketMaker) noexcept;
+    virtual Order &withMarketMaker(const StringLike &marketMaker) noexcept;
 
     /**
      * Returns a string representation of the current object.

--- a/include/dxfeed_graal_cpp_api/event/market/OrderBase.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OrderBase.hpp
@@ -10,7 +10,6 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
 #include "../../exceptions/InvalidArgumentException.hpp"
 #include "../../internal/Common.hpp"
 #include "../IndexedEvent.hpp"
-#include "../IndexedEventSource.hpp"
 #include "./MarketEvent.hpp"
 #include "./OrderAction.hpp"
 #include "./OrderSource.hpp"
@@ -31,7 +30,7 @@ DXFCPP_BEGIN_NAMESPACE
 struct EventMapper;
 
 /**
- * Base class for common fields of Order, AnalyticOrder and SpreadOrder events.
+ * Base class for common fields of Order, AnalyticOrder, and SpreadOrder events.
  * Order events represent a snapshot of a full available market depth for a symbol.
  * The collection of order events of a symbol represents the most recent information that is
  * available about orders on the market at any given moment of time.
@@ -52,7 +51,7 @@ struct EventMapper;
  * for the corresponding index.
  * The method @ref OrderBase::hasSize() "hasSize" is a convenient method to test for size presence.
  *
- * <h3><a name="eventFlagsSection">Event flags, transactions and snapshots</a></h3>
+ * <h3><a name="eventFlagsSection">Event flags, transactions, and snapshots.</a></h3>
  *
  * Some order event sources provide a consistent view of the price-level or detailed order book. Their updates
  * may incorporate multiple changes to price levels or to individual orders that have to be processed at the same time.
@@ -63,7 +62,7 @@ struct EventMapper;
  * OrderBase::getIndex() "index". It occupies the highest bits of the @ref OrderBase::getIndex() "index" (index is
  * not-negative). The lowest bits of
  * @ref OrderBase::getIndex() "index" contain source-specific event index which is always zero in
- * an event that is marked with EventFlag::SNAPSHOT_END bit in @ref OrderBase::getEventFlags() "eventFlags".
+ * an event that is marked with a EventFlag::SNAPSHOT_END bit in @ref OrderBase::getEventFlags() "eventFlags".
  *
  * <p> Note that for an order with EventFlag::REMOVE_EVENT bit in @ref OrderBase::getEventFlags() "eventFlags"
  * it is always the case that @ref #getSize() "size" is either `0` or `NaN`,
@@ -247,7 +246,7 @@ class DXFCPP_EXPORT OrderBase : public MarketEvent, public IndexedEvent {
 
     /**
      * Returns time of this order.
-     * Time is measured in milliseconds between the current time and midnight, January 1, 1970 UTC.
+     * Time is measured in milliseconds between the current time and midnight, January 1, 1970, UTC.
      *
      * @return time of this order.
      */
@@ -255,7 +254,7 @@ class DXFCPP_EXPORT OrderBase : public MarketEvent, public IndexedEvent {
 
     /**
      * Changes time of this order.
-     * Time is measured in milliseconds between the current time and midnight, January 1, 1970 UTC.
+     * Time is measured in milliseconds between the current time and midnight, January 1, 1970, UTC.
      *
      * @param time time of this order.
      */
@@ -296,7 +295,7 @@ class DXFCPP_EXPORT OrderBase : public MarketEvent, public IndexedEvent {
 
     /**
      * Returns time of this order in nanoseconds.
-     * Time is measured in nanoseconds between the current time and midnight, January 1, 1970 UTC.
+     * Time is measured in nanoseconds between the current time and midnight, January 1, 1970, UTC.
      *
      * @return time of this order in nanoseconds
      */
@@ -304,7 +303,7 @@ class DXFCPP_EXPORT OrderBase : public MarketEvent, public IndexedEvent {
 
     /**
      * Changes time of this order.
-     * Time is measured in nanoseconds between the current time and midnight, January 1, 1970 UTC.
+     * Time is measured in nanoseconds between the current time and midnight, January 1, 1970, UTC.
      *
      * @param timeNanos time of this order in nanoseconds.
      */
@@ -359,10 +358,10 @@ class DXFCPP_EXPORT OrderBase : public MarketEvent, public IndexedEvent {
     /**
      * Returns auxiliary order ID if available:
      * <ul>
-     * <li>in OrderAction::NEW - ID of the order replaced by this new order</li>
-     * <li>in OrderAction::DELETE - ID of the order that replaces this deleted order</li>
-     * <li>in OrderAction::PARTIAL - ID of the aggressor order</li>
-     * <li>in OrderAction::EXECUTE - ID of the aggressor order</li>
+     * <li>In OrderAction::NEW - ID of the order replaced by this new order.</li>
+     * <li>In OrderAction::DELETE - ID of the order that replaces this deleted order.</li>
+     * <li>In OrderAction::PARTIAL - ID of the aggressor order.</li>
+     * <li>In OrderAction::EXECUTE - ID of the aggressor order.</li>
      * </ul>
      * <p>This field is a part of the FOB support.
      *

--- a/include/dxfeed_graal_cpp_api/event/market/OtcMarketsOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OtcMarketsOrder.hpp
@@ -36,9 +36,8 @@ struct EventMapper;
  * <p>
  * For more information about original fields, QAP, Quote Flags and Extended Quote Flags,
  * see <a href="https://downloads.dxfeed.com/specifications/OTC_Markets_Multicast_Data_Feeds.pdf">OTC Markets Multicast
- * Data Feed</a>. <p> For more information about display requirements, see <a
- * href="https://downloads.dxfeed.com/specifications/OTC_Markets_Data_Display_Requirements.pdf">OTC Markets Display
- * Requirements</a>.
+ * Data Feed</a>.
+ * <p> For more information about display requirements, see <a href="https://downloads.dxfeed.com/specifications/OTC_Markets_Data_Display_Requirements.pdf">OTC Markets Display Requirements</a>.
  *
  * <p> Like regular orders, OTC Markets order events arrive from multiple sources for the same market symbol and are
  * distinguished by their @ref ::getIndex "index".
@@ -209,7 +208,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * midnight, January 1, 1970 UTC.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withEventTime(std::int64_t eventTime) noexcept;
+    OtcMarketsOrder &withEventTime(std::int64_t eventTime) noexcept override;
 
     // OrderBase methods
 
@@ -220,7 +219,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param source source of this event.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withSource(const OrderSource &source) noexcept;
+    OtcMarketsOrder &withSource(const OrderSource &source) noexcept override;
 
     /**
      * Changes transactional event flags and returns the current OTC Markets order.
@@ -229,7 +228,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param eventFlags transactional event flags.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withEventFlags(std::int32_t eventFlags) noexcept;
+    OtcMarketsOrder &withEventFlags(std::int32_t eventFlags) noexcept override;
 
     /**
      * Changes transactional event flags and returns the current OTC Markets order.
@@ -238,7 +237,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param eventFlags transactional event flags' mask.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withEventFlags(const EventFlagsMask &eventFlags) noexcept;
+    OtcMarketsOrder &withEventFlags(const EventFlagsMask &eventFlags) noexcept override;
 
     /**
      * Changes unique per-symbol index of this OTC Markets order and returns it. Note, that this method also changes
@@ -248,7 +247,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param index unique per-symbol index of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withIndex(std::int64_t index) noexcept;
+    OtcMarketsOrder &withIndex(std::int64_t index) noexcept override;
 
     /**
      * Changes time of this OTC Markets order and returns it.
@@ -257,7 +256,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param time time of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withTime(std::int64_t time) noexcept;
+    OtcMarketsOrder &withTime(std::int64_t time) noexcept override;
 
     /**
      * Changes microseconds and nanoseconds time part of this OTC Markets order.
@@ -266,7 +265,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param timeNanoPart microseconds and nanoseconds time part of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withTimeNanoPart(std::int32_t timeNanoPart) noexcept;
+    OtcMarketsOrder &withTimeNanoPart(std::int32_t timeNanoPart) noexcept override;
 
     /**
      * Changes @ref OrderBase::getSequence() "sequence number" of this OTC Markets order.
@@ -276,7 +275,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @return The current OTC Markets order.
      * @see OrderBase::getSequence()
      */
-    OtcMarketsOrder &withSequence(std::int32_t sequence) noexcept;
+    OtcMarketsOrder &withSequence(std::int32_t sequence) noexcept override;
 
     /**
      * Changes time of this OTC Markets order and returns it.
@@ -285,15 +284,15 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param timeNanos The time of this OTC Markets order in nanoseconds.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withTimeNanos(std::int64_t timeNanos) noexcept;
+    OtcMarketsOrder &withTimeNanos(std::int64_t timeNanos) noexcept override;
 
     /**
-     * Changes action of this OTC Markets order and returns it.
+     * Changes an action of this OTC Markets order and returns it.
      *
      * @param action The side of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withAction(const OrderAction &action) noexcept;
+    OtcMarketsOrder &withAction(const OrderAction &action) noexcept override;
 
     /**
      * Changes time of the last action and returns current OTC Markets order.
@@ -301,7 +300,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param actionTime The last order action time.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withActionTime(std::int64_t actionTime) noexcept;
+    OtcMarketsOrder &withActionTime(std::int64_t actionTime) noexcept override;
 
     /**
      * Changes order ID.
@@ -310,7 +309,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param orderId The order ID.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withOrderId(std::int64_t orderId) noexcept;
+    OtcMarketsOrder &withOrderId(std::int64_t orderId) noexcept override;
 
     /**
      * Changes auxiliary order ID.
@@ -319,7 +318,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param auxOrderId The auxiliary order ID.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withAuxOrderId(std::int64_t auxOrderId) noexcept;
+    OtcMarketsOrder &withAuxOrderId(std::int64_t auxOrderId) noexcept override;
 
     /**
      * Changes price of this OTC Markets order.
@@ -328,7 +327,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param price The price of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withPrice(double price) noexcept;
+    OtcMarketsOrder &withPrice(double price) noexcept override;
 
     /**
      * Changes size of this OTC Markets order.
@@ -337,7 +336,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param size The size of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withSize(double size) noexcept;
+    OtcMarketsOrder &withSize(double size) noexcept override;
 
     /**
      * Changes executed size of this OTC Markets order.
@@ -346,16 +345,16 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param executedSize The executed size of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withExecutedSize(double executedSize) noexcept;
+    OtcMarketsOrder &withExecutedSize(double executedSize) noexcept override;
 
     /**
-     * Changes number of individual orders in this aggregate order.
+     * Changes a number of individual orders in this aggregate order.
      * Returns the current OTC Markets order.
      *
      * @param count The number of individual orders in this aggregate order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withCount(std::int64_t count) noexcept;
+    OtcMarketsOrder &withCount(std::int64_t count) noexcept override;
 
     /**
      * Changes trade ID.
@@ -364,7 +363,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param tradeId The trade ID.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withTradeId(std::int64_t tradeId) noexcept;
+    OtcMarketsOrder &withTradeId(std::int64_t tradeId) noexcept override;
 
     /**
      * Changes trade price.
@@ -373,7 +372,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param tradePrice The trade price.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withTradePrice(double tradePrice) noexcept;
+    OtcMarketsOrder &withTradePrice(double tradePrice) noexcept override;
 
     /**
      * Changes trade size.
@@ -382,7 +381,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param tradeSize The trade size.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withTradeSize(double tradeSize) noexcept;
+    OtcMarketsOrder &withTradeSize(double tradeSize) noexcept override;
 
     /**
      * Changes exchange code of this OTC Markets order.
@@ -391,7 +390,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param exchangeCode The exchange code of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withExchangeCode(char exchangeCode) noexcept;
+    OtcMarketsOrder &withExchangeCode(char exchangeCode) noexcept override;
 
     /**
      * Changes exchange code of this OTC Markets order.
@@ -400,7 +399,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param exchangeCode The exchange code of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withExchangeCode(std::int16_t exchangeCode) noexcept;
+    OtcMarketsOrder &withExchangeCode(std::int16_t exchangeCode) noexcept override;
 
     /**
      * Changes side of this OTC Markets order.
@@ -409,7 +408,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param side The side of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withOrderSide(const Side &side) noexcept;
+    OtcMarketsOrder &withOrderSide(const Side &side) noexcept override;
 
     /**
      * Changes scope of this OTC Markets order.
@@ -418,7 +417,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param scope The scope of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withScope(const Scope &scope) noexcept;
+    OtcMarketsOrder &withScope(const Scope &scope) noexcept override;
 
     // Order methods
 
@@ -429,7 +428,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @param marketMaker The market maker or another aggregate identifier of this OTC Markets order.
      * @return The current OTC Markets order.
      */
-    OtcMarketsOrder &withMarketMaker(const StringLike& marketMaker) noexcept;
+    OtcMarketsOrder &withMarketMaker(const StringLike& marketMaker) noexcept override;
 
     // OtcMarketsOrder methods
 

--- a/scripts/make-source-bundle.ps1
+++ b/scripts/make-source-bundle.ps1
@@ -43,7 +43,7 @@ else
     Copy-Item -Path "$thisDir/../*.txt" -Force -Destination "$bundlePath"
     Copy-Item -Path "$thisDir/../LICENSE" -Force -Destination "$bundlePath"
     Copy-Item -Path "$thisDir/../.clang-format" -Force -Destination "$bundlePath"
-    Invoke-WebRequest -Uri "https://dxfeed.jfrog.io/artifactory/maven-open/com/dxfeed/graal-native-sdk/${graalNativeSdkVer}/graal-native-sdk-${graalNativeSdkVer}-amd64-windows.zip" -OutFile "$downloadPath/graal-native-sdk-${graalNativeSdkVer}-amd64-windows.zip"
+    Invoke-WebRequest -Uri "https://github.com/dxFeed/dxfeed-graal-native-sdk/releases/download/v${graalNativeSdkVer}/graal-native-sdk-${graalNativeSdkVer}-amd64-windows.zip" -OutFile "$downloadPath/graal-native-sdk-${graalNativeSdkVer}-amd64-windows.zip"
     Expand-Archive -Path "$downloadPath/graal-native-sdk-${graalNativeSdkVer}-amd64-windows.zip" -Force -DestinationPath "$bundlePath/third_party/graal-native-sdk-${graalNativeSdkVer}-amd64-windows"
-    Compress-Archive -Path "$bundlePath" -DestinationPath "$buildBundleDir/$bundleName.zip"
+    Compress-Archive -Force -Path "$bundlePath" -DestinationPath "$buildBundleDir/$bundleName.zip"
 }


### PR DESCRIPTION
* **\[MDAPI-417]** **\[BREAKING]** All methods of the `Order` class and its descendants whose names begin with "with" are made virtual.
* The project now depends on the zip bundles of the dxFeed Graal Native SDK library, which are located in GitHub Releases.