### PR TITLE
[MDAPI-423][C++] Fixed Java-to-C++ porting errors in packed event fields, native conversions, string handling, and candle attributes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(DXFCXX_VERSION "v7.0.0" CACHE STRING "The dxFeed Graal CXX API package versi
 
 dxfcxx_ParseVersion(${DXFCXX_VERSION} DXFCXX_MAJOR_VERSION DXFCXX_MINOR_VERSION DXFCXX_PATCH_VERSION DXFCXX_SUFFIX_VERSION)
 
-set(DXFEED_GRAAL_NATIVE_SDK_VERSION "3.2.0" CACHE STRING "")
+set(DXFEED_GRAAL_NATIVE_SDK_VERSION "3.2.13" CACHE STRING "")
 set(FMTLIB_VERSION "12.1.0")
 set(BOOST_VERSION "1.84.0")
 set(UTFCPP_VERSION "3.2.3")
@@ -70,7 +70,7 @@ option(DXFCXX_NODEFAULTLIB "Ignore libcmt/libcmtd/msvcrt/msvcrtd. Use if DXFCXX_
 option(DXFCXX_ENABLE_METRICS "Enable metrics collection" OFF)
 
 option(DXFCXX_USE_DXFEED_GRAAL_NATIVE_SDK_GITHUB "" ON)
-set(DXFEED_GRAAL_NATIVE_SDK_JFROG_BASE_URL "https://github.com/dxFeed/dxfeed-graal-native-sdk/releases/download/" CACHE STRING "")
+set(DXFEED_GRAAL_NATIVE_SDK_BASE_URL "https://github.com/dxFeed/dxfeed-graal-native-sdk/releases/download/" CACHE STRING "")
 option(DXFCXX_USE_DEBUG_DXFEED_GRAAL_NATIVE_SDK "" OFF)
 
 option(DXFCXX_USE_DXFG_STUB "Use dxFeed Graal SDK stub" OFF)
@@ -138,7 +138,7 @@ else ()
                 )
             else ()
                 if (DXFCXX_USE_DXFEED_GRAAL_NATIVE_SDK_GITHUB)
-                    set(DXFEED_GRAAL_NATIVE_SDK_URL "${DXFEED_GRAAL_NATIVE_SDK_JFROG_BASE_URL}v${DXFEED_GRAAL_NATIVE_SDK_VERSION}/graal-native-sdk-${DXFEED_GRAAL_NATIVE_SDK_VERSION}")
+                    set(DXFEED_GRAAL_NATIVE_SDK_URL "${DXFEED_GRAAL_NATIVE_SDK_BASE_URL}v${DXFEED_GRAAL_NATIVE_SDK_VERSION}/graal-native-sdk-${DXFEED_GRAAL_NATIVE_SDK_VERSION}")
                 endif ()
 
                 if (DXFCXX_GRAAL_TARGET_PLATFORM STREQUAL "unknown-unknown")

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,7 +2,7 @@
 
 ## Compile-time
 
-- [dxFeed Graal Native SDK](https://github.com/dxFeed/dxfeed-graal-native-sdk) v3.2.0
+- [dxFeed Graal Native SDK](https://github.com/dxFeed/dxfeed-graal-native-sdk) v3.2.13
   - [Bundles](https://dxfeed.jfrog.io/artifactory/maven-open/com/dxfeed/graal-native-sdk/) 
 - \[opt] [Boost](https://github.com/boostorg/boost) v1.84.0
   - Boost.Stacktrace 1.0
@@ -29,7 +29,7 @@
     - addr2line \[opt] (Diagnostic backtraces)
 ## Run-time
 
-- [dxFeed Graal Native SDK](https://github.com/dxFeed/dxfeed-graal-native-sdk) v3.2.0
+- [dxFeed Graal Native SDK](https://github.com/dxFeed/dxfeed-graal-native-sdk) v3.2.13
 - [doctest](https://github.com/doctest/doctest) v2.4.11 (Tests)
 - [nanobench](https://github.com/martinus/nanobench) v4.3.11 (Tests::Benchmarks)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and [dxFeed Java API](https://docs.dxfeed.com/dxfeed/api/overview-summary.html) 
 the [Overview](#overview) section.<br>
 
 [![Build](https://github.com/dxFeed/dxfeed-graal-cxx-api/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/dxFeed/dxfeed-graal-cxx-api/actions/workflows/build.yml)
-![Graal Native SDK](https://img.shields.io/badge/Graal%20Native%20SDK-v3.2.0-yellow)
+![Graal Native SDK](https://img.shields.io/badge/Graal%20Native%20SDK-v3.2.13-yellow)
 ![Platform](https://img.shields.io/badge/platform-win--x64%20%7C%20linux--x64%20%7C%20linux--aarch64%20%7C%20osx--x64%20%7C%20osx--aarch64-lightgrey)
 ![](https://img.shields.io/badge/C++%20standard-C++20-blueviolet) ![](https://img.shields.io/badge/C%20standard-C11-blueviolet)
 [![Release](https://img.shields.io/github/v/release/dxFeed/dxfeed-graal-cxx-api)](https://github.com/dxFeed/dxfeed-graal-cxx-api/releases/latest)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,16 @@
+## v8.0.0
+
+* **\[MDAPI-423]\[C++]** **\[BREAKING]** Fixed Java-to-C++ porting errors in packed event fields, native
+  conversions, string handling, and candle attributes.
+    * `setSequence()` and `OrderBase::setSource()` now preserve unrelated packed bits; `Message` native conversion
+      preserves event time; `StringLike` copy/move operations and native C-string handling are now safe.
+    * Candle equality, formatting, price-level validation/parsing, and session parsing now match Java QD semantics.
+      Price levels reject negative values, negative zero, infinities, and trailing parse data; floating-point equality
+      follows Java NaN/signed-zero rules; only case-insensitive `"true"` enables the regular candle session.
+    * APIs that can fail validation or parsing are no longer `noexcept`; invalid input now throws an exception instead
+      of terminating the process.
+* Migrated to Graal SDK v3.2.13.
+
 ## v7.0.0
 
 * **\[MDAPI-417]** **\[BREAKING]** All methods of the `Order` class and its descendants whose names begin with "with" are made virtual.

--- a/deps.json
+++ b/deps.json
@@ -3,7 +3,7 @@
   "date": "3.0.1",
   "doctest": "2.4.11",
   "fmt": "12.1.0",
-  "graal-native-sdk": "3.2.0",
+  "graal-native-sdk": "3.2.13",
   "Process": "3.0.1",
   "range-v3": "0.12",
   "utfcpp": "3.2.3",

--- a/include/dxfeed_graal_cpp_api/event/candle/Candle.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/Candle.hpp
@@ -304,7 +304,7 @@ class DXFCPP_EXPORT Candle final : public EventTypeWithSymbol<CandleSymbol>,
      * @return The current candle.
      * @see Candle::getSequence()
      */
-    Candle &withSequence(std::int32_t sequence) noexcept;
+    Candle &withSequence(std::int32_t sequence);
 
     /**
      * Returns total number of original trade (or quote) events in this candle.

--- a/include/dxfeed_graal_cpp_api/event/candle/CandlePeriod.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandlePeriod.hpp
@@ -12,6 +12,8 @@ DXFCXX_DISABLE_MSC_WARNINGS_PUSH(4251)
 #include "./CandleSymbolAttribute.hpp"
 #include "./CandleType.hpp"
 
+#include <cmath>
+#include <limits>
 #include <string>
 
 /**
@@ -150,7 +152,7 @@ struct DXFCPP_EXPORT CandlePeriod : public CandleSymbolAttribute {
      * @param symbol candle symbol string.
      * @return candle period of the given candle symbol string
      */
-    static CandlePeriod getAttributeForSymbol(const StringLike &symbol) noexcept;
+    static CandlePeriod getAttributeForSymbol(const StringLike &symbol);
 
     /**
      * Returns candle symbol string with the normalized representation of the candle period attribute.
@@ -169,7 +171,9 @@ template <> struct std::hash<dxfcpp::CandlePeriod> {
     std::size_t operator()(const dxfcpp::CandlePeriod &candlePeriod) const noexcept {
         std::size_t seed = 0;
 
-        dxfcpp::hashCombine(seed, candlePeriod.getValue());
+        const auto value = candlePeriod.getValue();
+
+        dxfcpp::hashCombine(seed, std::isnan(value) ? std::numeric_limits<double>::quiet_NaN() : value);
         dxfcpp::hashCombine(seed, candlePeriod.getType());
 
         return seed;

--- a/include/dxfeed_graal_cpp_api/event/candle/CandlePrice.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandlePrice.hpp
@@ -127,7 +127,7 @@ struct DXFCPP_EXPORT CandlePrice : CandleSymbolAttribute {
      * @param symbol The candle symbol string.
      * @return candle price type of the given candle symbol string.
      */
-    static std::reference_wrapper<const CandlePrice> getAttributeForSymbol(const StringLike &symbol) noexcept;
+    static std::reference_wrapper<const CandlePrice> getAttributeForSymbol(const StringLike &symbol);
 
     /**
      * Returns candle symbol string with the normalized representation of the candle price type attribute.

--- a/include/dxfeed_graal_cpp_api/event/candle/CandleSymbol.hpp
+++ b/include/dxfeed_graal_cpp_api/event/candle/CandleSymbol.hpp
@@ -97,11 +97,10 @@ struct DXFCPP_EXPORT CandleSymbol {
     std::optional<CandleAlignment> alignment_{};
     std::optional<CandlePriceLevel> priceLevel_{};
 
-    static std::string changeAttribute(const StringLike &symbol,
-                                       const CandleSymbolAttributeVariant &attribute) noexcept;
+    static std::string changeAttribute(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute);
 
     template <typename AttributeIt>
-    static std::string changeAttributes(const StringLike &s, AttributeIt begin, AttributeIt end) noexcept {
+    static std::string changeAttributes(const StringLike &s, AttributeIt begin, AttributeIt end) {
         auto symbol = std::string(s);
 
         for (auto it = begin; it != end; ++it) {
@@ -111,16 +110,16 @@ struct DXFCPP_EXPORT CandleSymbol {
         return symbol;
     }
 
-    static std::string normalize(const StringLike &s) noexcept;
+    static std::string normalize(const StringLike &s);
 
-    void initTransientFields(bool force = false) noexcept;
+    void initTransientFields(bool force = false);
 
-    explicit CandleSymbol(const StringLike &symbol) noexcept;
+    explicit CandleSymbol(const StringLike &symbol);
 
-    CandleSymbol(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute) noexcept;
+    CandleSymbol(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute);
 
     template <typename CandleSymbolAttributeIt>
-    CandleSymbol(const StringLike &symbol, CandleSymbolAttributeIt begin, CandleSymbolAttributeIt end) noexcept
+    CandleSymbol(const StringLike &symbol, CandleSymbolAttributeIt begin, CandleSymbolAttributeIt end)
         : symbol_{normalize(changeAttributes(symbol, begin, end))} {
         initTransientFields();
     }
@@ -227,7 +226,7 @@ struct DXFCPP_EXPORT CandleSymbol {
      * @param symbol The string symbol.
      * @return The candle symbol object.
      */
-    static CandleSymbol valueOf(const StringLike &symbol) noexcept;
+    static CandleSymbol valueOf(const StringLike &symbol);
 
     /**
      * Converts the given string symbol into the candle symbol object with the specified attribute set.
@@ -236,7 +235,7 @@ struct DXFCPP_EXPORT CandleSymbol {
      * @param attribute The attribute to set.
      * @return The candle symbol object.
      */
-    static CandleSymbol valueOf(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute) noexcept;
+    static CandleSymbol valueOf(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute);
 
     /**
      * Converts the given string symbol into the candle symbol object with the specified attribute set (iterators).
@@ -249,7 +248,7 @@ struct DXFCPP_EXPORT CandleSymbol {
      */
     template <typename CandleSymbolAttributeIt>
     static CandleSymbol valueOf(const StringLike &symbol, CandleSymbolAttributeIt begin,
-                                CandleSymbolAttributeIt end) noexcept {
+                                CandleSymbolAttributeIt end) {
         return CandleSymbol{symbol, begin, end};
     }
 
@@ -262,7 +261,7 @@ struct DXFCPP_EXPORT CandleSymbol {
      * @return The candle symbol object.
      */
     static CandleSymbol valueOf(const StringLike &symbol,
-                                std::initializer_list<CandleSymbolAttributeVariant> attributes) noexcept;
+                                std::initializer_list<CandleSymbolAttributeVariant> attributes);
 
     /**
      * Converts the given string symbol into the candle symbol object with the specified attributes set.
@@ -277,7 +276,7 @@ struct DXFCPP_EXPORT CandleSymbol {
             { std::begin(attributes) };
             { std::end(attributes) };
         }
-    static CandleSymbol valueOf(const StringLike &symbol, CandleSymbolAttributesCollection &&attributes) noexcept {
+    static CandleSymbol valueOf(const StringLike &symbol, CandleSymbolAttributesCollection &&attributes) {
         return valueOf(symbol, std::begin(attributes), std::end(attributes));
     }
 };
@@ -291,7 +290,7 @@ inline namespace literals {
  * @param length Tha char array's length
  * @return Wrapped string view built on char array
  */
-CandleSymbol operator""_c(const char *string, size_t length) noexcept;
+CandleSymbol operator""_c(const char *string, size_t length);
 
 } // namespace literals
 

--- a/include/dxfeed_graal_cpp_api/event/market/AnalyticOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/AnalyticOrder.hpp
@@ -210,7 +210,7 @@ class DXFCPP_EXPORT AnalyticOrder final : public Order {
      * @return The current analytic order.
      * @see OrderBase::getSequence()
      */
-    AnalyticOrder &withSequence(std::int32_t sequence) noexcept override;
+    AnalyticOrder &withSequence(std::int32_t sequence) override;
 
     /**
      * Changes time of this analytic order and returns it.

--- a/include/dxfeed_graal_cpp_api/event/market/OptionSale.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OptionSale.hpp
@@ -355,7 +355,7 @@ class DXFCPP_EXPORT OptionSale final : public MarketEvent, public IndexedEvent {
      * @return The current option sale.
      * @see ::getSequence()
      */
-    OptionSale &withSequence(std::int32_t sequence) noexcept;
+    OptionSale &withSequence(std::int32_t sequence);
 
     /**
      * Returns exchange code of this option sale event.

--- a/include/dxfeed_graal_cpp_api/event/market/Order.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Order.hpp
@@ -242,7 +242,7 @@ class DXFCPP_EXPORT Order : public OrderBase {
      * @return The current order.
      * @see OrderBase::getSequence()
      */
-    virtual Order &withSequence(std::int32_t sequence) noexcept;
+    virtual Order &withSequence(std::int32_t sequence);
 
     /**
      * Changes time of this order and returns it.

--- a/include/dxfeed_graal_cpp_api/event/market/OtcMarketsOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/OtcMarketsOrder.hpp
@@ -275,7 +275,7 @@ class DXFCPP_EXPORT OtcMarketsOrder final : public Order {
      * @return The current OTC Markets order.
      * @see OrderBase::getSequence()
      */
-    OtcMarketsOrder &withSequence(std::int32_t sequence) noexcept override;
+    OtcMarketsOrder &withSequence(std::int32_t sequence) override;
 
     /**
      * Changes time of this OTC Markets order and returns it.

--- a/include/dxfeed_graal_cpp_api/event/market/Quote.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/Quote.hpp
@@ -158,7 +158,7 @@ class DXFCPP_EXPORT Quote final : public MarketEvent, public LastingEvent {
      * @return The current quote.
      * @see Quote::getSequence()
      */
-    Quote &withSequence(std::int32_t sequence) noexcept;
+    Quote &withSequence(std::int32_t sequence);
 
     /**
      * Returns time of the last bid or ask change.

--- a/include/dxfeed_graal_cpp_api/event/market/SpreadOrder.hpp
+++ b/include/dxfeed_graal_cpp_api/event/market/SpreadOrder.hpp
@@ -235,7 +235,7 @@ class DXFCPP_EXPORT SpreadOrder : public OrderBase {
      * @return The current spread order.
      * @see OrderBase::getSequence()
      */
-    SpreadOrder &withSequence(std::int32_t sequence) noexcept;
+    SpreadOrder &withSequence(std::int32_t sequence);
 
     /**
      * Changes time of this spread order and returns it.

--- a/include/dxfeed_graal_cpp_api/event/misc/TextMessage.hpp
+++ b/include/dxfeed_graal_cpp_api/event/misc/TextMessage.hpp
@@ -234,7 +234,7 @@ class DXFCPP_EXPORT TextMessage : public EventTypeWithSymbol<std::string> {
      * @return The current message.
      * @throws InvalidArgumentException if a sequence is below zero or above #MAX_SEQUENCE.
      */
-    TextMessage &withSequence(std::int32_t sequence) noexcept;
+    TextMessage &withSequence(std::int32_t sequence);
 
     /**
      * Returns text.

--- a/include/dxfeed_graal_cpp_api/event/option/Series.hpp
+++ b/include/dxfeed_graal_cpp_api/event/option/Series.hpp
@@ -293,7 +293,7 @@ class DXFCPP_EXPORT Series final : public MarketEvent, public IndexedEvent {
      * @return The current series.
      * @see Series::getSequence()
      */
-    Series &withSequence(std::int32_t sequence) noexcept;
+    Series &withSequence(std::int32_t sequence);
 
     /**
      * Returns day id of expiration.

--- a/include/dxfeed_graal_cpp_api/glossary/AdditionalUnderlyings.hpp
+++ b/include/dxfeed_graal_cpp_api/glossary/AdditionalUnderlyings.hpp
@@ -180,8 +180,12 @@ AdditionalUnderlyings::Ptr AdditionalUnderlyings::valueOf(const MapLikeType &map
     mapLikeEntries.reserve(map.size());
 
     if constexpr (std::is_convertible_v<KeyType, std::string_view>) {
+        std::vector<std::string> keyStorage;
+        keyStorage.reserve(map.size());
+
         for (const auto &[key, value] : map) {
-            mapLikeEntries.emplace_back(std::string_view(key).data(), static_cast<double>(value));
+            keyStorage.emplace_back(std::string_view(key));
+            mapLikeEntries.emplace_back(keyStorage.back().c_str(), static_cast<double>(value));
         }
 
         return createShared(valueOfImpl(mapLikeEntries));

--- a/include/dxfeed_graal_cpp_api/internal/Common.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/Common.hpp
@@ -293,6 +293,38 @@ static constexpr std::int64_t floorMod(std::int64_t x, std::int64_t y) {
 
 static const double NaN = std::numeric_limits<double>::quiet_NaN();
 
+/**
+ * Compares two double values using Java @c Double.equals semantics.
+ * All NaN values are considered equal, while positive and negative zero are considered different.
+ *
+ * @param a The first value.
+ * @param b The second value.
+ * @return @c true if the values are equal; @c false otherwise.
+ */
+inline bool doubleEquals(double a, double b) noexcept {
+    if (std::isnan(a) || std::isnan(b)) {
+        return std::isnan(a) && std::isnan(b);
+    }
+
+    if (a != b) {
+        return false;
+    }
+
+    return a != 0.0 || std::signbit(a) == std::signbit(b);
+}
+
+/**
+ * Checks whether a double value can be safely converted to @c std::int64_t without losing its fractional part.
+ *
+ * @param value The value to check.
+ * @return @c true if the value is finite, integral, and within the range of @c std::int64_t;
+ *         @c false otherwise.
+ */
+inline bool isInt64(double value) noexcept {
+    return std::isfinite(value) && value >= static_cast<double>(std::numeric_limits<std::int64_t>::min()) &&
+           value < -static_cast<double>(std::numeric_limits<std::int64_t>::min()) && value == std::trunc(value);
+}
+
 inline bool equals(double a, double b, double eps = std::numeric_limits<double>::epsilon()) {
     if (std::isnan(a) || std::isnan(b)) {
         return false;

--- a/include/dxfeed_graal_cpp_api/internal/utils/StringUtils.hpp
+++ b/include/dxfeed_graal_cpp_api/internal/utils/StringUtils.hpp
@@ -42,6 +42,14 @@ struct StringLike {
     // ReSharper disable once CppNonExplicitConvertingConstructor
     StringLike(std::string &&s) noexcept;
 
+    StringLike(const StringLike &other);
+
+    StringLike(StringLike &&other) noexcept;
+
+    StringLike &operator=(const StringLike &other);
+
+    StringLike &operator=(StringLike &&other) noexcept;
+
     // ReSharper disable once CppNonExplicitConvertingConstructor
     template <std::size_t N> StringLike(const char (&arr)[N]) : view_(arr, N - 1) {
     }

--- a/src/event/candle/Candle.cpp
+++ b/src/event/candle/Candle.cpp
@@ -259,10 +259,10 @@ void Candle::setSequence(std::int32_t sequence) {
             fmt::format(ires::Strings::Events::INVALID_VALUE_FOR_ARG, "sequence", std::to_string(sequence)));
     }
 
-    data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);
+    data_.index = orOp(andOp(data_.index, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
-Candle &Candle::withSequence(std::int32_t sequence) noexcept {
+Candle &Candle::withSequence(std::int32_t sequence) {
     setSequence(sequence);
 
     return *this;

--- a/src/event/candle/CandlePeriod.cpp
+++ b/src/event/candle/CandlePeriod.cpp
@@ -34,17 +34,17 @@ const CandleType &CandlePeriod::getType() const & noexcept {
 
 const std::string &CandlePeriod::toString() const & {
     if (string_.empty()) {
-        string_ = math::equals(value_, DEFAULT_PERIOD_VALUE) ? type_.toString()
-                  : math::equals(value_, static_cast<std::int64_t>(value_))
+        string_ = math::doubleEquals(value_, DEFAULT_PERIOD_VALUE) ? type_.toString()
+                  : math::isInt64(value_)
                       ? std::to_string(static_cast<std::int64_t>(value_)) + "" + type_.toString()
-                      : std::to_string(value_) + "" + type_.toString();
+                      : dxfcpp::toString(value_) + "" + type_.toString();
     }
 
     return string_;
 }
 
 bool CandlePeriod::operator==(const CandlePeriod &candlePeriod) const {
-    return math::equals(value_, candlePeriod.getValue()) && type_ == candlePeriod.getType();
+    return math::doubleEquals(value_, candlePeriod.getValue()) && type_ == candlePeriod.getType();
 }
 
 CandlePeriod CandlePeriod::parse(const StringLike &s) {
@@ -87,7 +87,7 @@ CandlePeriod CandlePeriod::valueOf(double value, const CandleType &type) noexcep
     return {value, type};
 }
 
-CandlePeriod CandlePeriod::getAttributeForSymbol(const StringLike &symbol) noexcept {
+CandlePeriod CandlePeriod::getAttributeForSymbol(const StringLike &symbol) {
     const auto string = MarketEventSymbols::getAttributeStringByKey(symbol, ATTRIBUTE_KEY);
 
     return !string ? DEFAULT : parse(string.value());

--- a/src/event/candle/CandlePrice.cpp
+++ b/src/event/candle/CandlePrice.cpp
@@ -49,7 +49,7 @@ std::reference_wrapper<const CandlePrice> CandlePrice::parse(const StringLike &s
     throw InvalidArgumentException(fmt::format(ires::Strings::Events::UNKNOWN_CANDLE_, "price", s.toStringView()));
 }
 
-std::reference_wrapper<const CandlePrice> CandlePrice::getAttributeForSymbol(const StringLike &symbol) noexcept {
+std::reference_wrapper<const CandlePrice> CandlePrice::getAttributeForSymbol(const StringLike &symbol) {
     const auto stringOpt = MarketEventSymbols::getAttributeStringByKey(symbol, ATTRIBUTE_KEY);
 
     return !stringOpt ? std::cref(DEFAULT) : parse(stringOpt.value());

--- a/src/event/candle/CandlePriceLevel.cpp
+++ b/src/event/candle/CandlePriceLevel.cpp
@@ -19,15 +19,11 @@ double CandlePriceLevel::getValue() const noexcept {
 }
 
 std::string CandlePriceLevel::toString() const {
-    if (math::equals(value_, static_cast<std::int64_t>(value_))) {
-        return std::to_string(static_cast<std::int64_t>(value_));
-    }
-
-    return std::to_string(value_);
+    return math::isInt64(value_) ? std::to_string(static_cast<std::int64_t>(value_)) : dxfcpp::toString(value_);
 }
 
 bool CandlePriceLevel::operator==(const CandlePriceLevel &candlePriceLevel) const noexcept {
-    return math::equals(value_, candlePriceLevel.getValue());
+    return math::doubleEquals(value_, candlePriceLevel.getValue());
 }
 
 std::string CandlePriceLevel::changeAttributeForSymbol(const StringLike &symbol) const {
@@ -36,11 +32,26 @@ std::string CandlePriceLevel::changeAttributeForSymbol(const StringLike &symbol)
 }
 
 CandlePriceLevel CandlePriceLevel::parse(const StringLike &s) {
-    return valueOf(std::stod(s));
+    const auto string = std::string{s};
+    std::size_t parsedLength = 0;
+
+    try {
+        const auto value = std::stod(string, &parsedLength);
+
+        if (parsedLength != string.size()) {
+            throw InvalidArgumentException("Incorrect candle price level: " + string);
+        }
+
+        return valueOf(value);
+    } catch (const InvalidArgumentException &) {
+        throw;
+    } catch (const std::exception &) {
+        throw InvalidArgumentException("Incorrect candle price level: " + string);
+    }
 }
 
 CandlePriceLevel CandlePriceLevel::valueOf(double value) {
-    if (std::isinf(value) || (value == 0.0 && std::signbit(value))) {
+    if (std::isinf(value) || (!std::isnan(value) && std::signbit(value))) {
         throw InvalidArgumentException("Incorrect candle price level: " + dxfcpp::toString(value));
     }
 

--- a/src/event/candle/CandleSession.cpp
+++ b/src/event/candle/CandleSession.cpp
@@ -130,7 +130,7 @@ std::reference_wrapper<const CandleSession> CandleSession::parse(const StringLik
 std::reference_wrapper<const CandleSession> CandleSession::getAttributeForSymbol(const StringLike &symbol) {
     const auto stringOpt = MarketEventSymbols::getAttributeStringByKey(symbol, ATTRIBUTE_KEY);
 
-    return !stringOpt ? std::cref(DEFAULT) : parse(stringOpt.value());
+    return stringOpt && iEquals(stringOpt.value(), "true") ? std::cref(REGULAR) : std::cref(DEFAULT);
 }
 
 std::string CandleSession::normalizeAttributeForSymbol(const StringLike &symbol) noexcept {

--- a/src/event/candle/CandleSymbol.cpp
+++ b/src/event/candle/CandleSymbol.cpp
@@ -149,8 +149,7 @@ const std::vector<std::reference_wrapper<const CandleSession>> CandleSession::VA
 
 const CandleSymbol CandleSymbol::NUL{"<null>"};
 
-std::string CandleSymbol::changeAttribute(const StringLike &symbol,
-                                          const CandleSymbolAttributeVariant &attribute) noexcept {
+std::string CandleSymbol::changeAttribute(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute) {
     return std::visit(
         [&symbol](auto &&a) {
             return a.changeAttributeForSymbol(symbol);
@@ -158,7 +157,7 @@ std::string CandleSymbol::changeAttribute(const StringLike &symbol,
         attribute);
 }
 
-std::string CandleSymbol::normalize(const StringLike &s) noexcept {
+std::string CandleSymbol::normalize(const StringLike &s) {
     auto symbol = CandlePrice::normalizeAttributeForSymbol(s);
 
     symbol = CandleSession::normalizeAttributeForSymbol(symbol);
@@ -169,7 +168,7 @@ std::string CandleSymbol::normalize(const StringLike &s) noexcept {
     return symbol;
 }
 
-void CandleSymbol::initTransientFields(bool force) noexcept {
+void CandleSymbol::initTransientFields(bool force) {
     baseSymbol_ = MarketEventSymbols::getBaseSymbol(symbol_);
 
     if (!exchange_ || force) {
@@ -197,11 +196,11 @@ void CandleSymbol::initTransientFields(bool force) noexcept {
     }
 }
 
-CandleSymbol::CandleSymbol(const StringLike &symbol) noexcept : symbol_{normalize(symbol)} {
+CandleSymbol::CandleSymbol(const StringLike &symbol) : symbol_{normalize(symbol)} {
     initTransientFields();
 }
 
-CandleSymbol::CandleSymbol(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute) noexcept
+CandleSymbol::CandleSymbol(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute)
     : symbol_{normalize(changeAttribute(symbol, attribute))} {
     // TODO: check attributes
     initTransientFields();
@@ -327,20 +326,20 @@ CandleSymbol CandleSymbol::fromGraal(void *graalNative) {
     return CandleSymbol{graalSymbol->symbol};
 }
 
-CandleSymbol CandleSymbol::valueOf(const StringLike &symbol) noexcept {
+CandleSymbol CandleSymbol::valueOf(const StringLike &symbol) {
     return CandleSymbol{symbol};
 }
 
-CandleSymbol CandleSymbol::valueOf(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute) noexcept {
+CandleSymbol CandleSymbol::valueOf(const StringLike &symbol, const CandleSymbolAttributeVariant &attribute) {
     return CandleSymbol{symbol, attribute};
 }
 
 CandleSymbol CandleSymbol::valueOf(const StringLike &symbol,
-                                   std::initializer_list<CandleSymbolAttributeVariant> attributes) noexcept {
+                                   std::initializer_list<CandleSymbolAttributeVariant> attributes) {
     return valueOf(symbol, attributes.begin(), attributes.end());
 }
 
-CandleSymbol literals::operator""_c(const char *string, size_t length) noexcept {
+CandleSymbol literals::operator""_c(const char *string, size_t length) {
     return CandleSymbol::valueOf(std::string{string, length});
 }
 DXFCPP_END_NAMESPACE

--- a/src/event/market/AnalyticOrder.cpp
+++ b/src/event/market/AnalyticOrder.cpp
@@ -145,7 +145,7 @@ AnalyticOrder &AnalyticOrder::withTimeNanoPart(std::int32_t timeNanoPart) noexce
     return dynamic_cast<AnalyticOrder &>(Order::withTimeNanoPart(timeNanoPart));
 }
 
-AnalyticOrder &AnalyticOrder::withSequence(std::int32_t sequence) noexcept {
+AnalyticOrder &AnalyticOrder::withSequence(std::int32_t sequence) {
     return dynamic_cast<AnalyticOrder &>(Order::withSequence(sequence));
 }
 

--- a/src/event/market/OptionSale.cpp
+++ b/src/event/market/OptionSale.cpp
@@ -283,10 +283,10 @@ void OptionSale::setSequence(std::int32_t sequence) {
         throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
     }
 
-    data_.timeSequence = orOp(andOp(data_.timeSequence, ~MAX_SEQUENCE), sequence);
+    data_.timeSequence = orOp(andOp(data_.timeSequence, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
-OptionSale &OptionSale::withSequence(std::int32_t sequence) noexcept {
+OptionSale &OptionSale::withSequence(std::int32_t sequence) {
     setSequence(sequence);
 
     return *this;

--- a/src/event/market/Order.cpp
+++ b/src/event/market/Order.cpp
@@ -163,7 +163,7 @@ Order &Order::withTimeNanoPart(std::int32_t timeNanoPart) noexcept {
     return *this;
 }
 
-Order &Order::withSequence(std::int32_t sequence) noexcept {
+Order &Order::withSequence(std::int32_t sequence) {
     setSequence(sequence);
 
     return *this;

--- a/src/event/market/OrderBase.cpp
+++ b/src/event/market/OrderBase.cpp
@@ -96,7 +96,8 @@ void OrderBase::setSource(const OrderSource &source) noexcept {
             ? ~sal(std::int64_t{-1}, SPECIAL_SOURCE_ID_SHIFT)
             : ~sal(std::int64_t{-1}, NONSPECIAL_SOURCE_ID_SHIFT);
 
-    orderBaseData_.index = andOp(sal(static_cast<std::int64_t>(source.id()), shift), andOp(orderBaseData_.index, mask));
+    orderBaseData_.index = orOp(sal(static_cast<std::int64_t>(source.id()), shift),
+                                andOp(orderBaseData_.index, mask));
 }
 
 std::int32_t OrderBase::getEventFlags() const noexcept {
@@ -164,7 +165,8 @@ void OrderBase::setSequence(std::int32_t sequence) {
         throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
     }
 
-    orderBaseData_.timeSequence = orOp(andOp(orderBaseData_.timeSequence, ~MAX_SEQUENCE), sequence);
+    orderBaseData_.timeSequence =
+        orOp(andOp(orderBaseData_.timeSequence, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
 std::int64_t OrderBase::getTimeNanos() const noexcept {

--- a/src/event/market/OtcMarketsOrder.cpp
+++ b/src/event/market/OtcMarketsOrder.cpp
@@ -138,7 +138,7 @@ OtcMarketsOrder &OtcMarketsOrder::withTimeNanoPart(std::int32_t timeNanoPart) no
     return dynamic_cast<OtcMarketsOrder &>(Order::withTimeNanoPart(timeNanoPart));
 }
 
-OtcMarketsOrder &OtcMarketsOrder::withSequence(std::int32_t sequence) noexcept {
+OtcMarketsOrder &OtcMarketsOrder::withSequence(std::int32_t sequence) {
     return dynamic_cast<OtcMarketsOrder &>(Order::withSequence(sequence));
 }
 

--- a/src/event/market/Quote.cpp
+++ b/src/event/market/Quote.cpp
@@ -286,7 +286,7 @@ void Quote::setSequence(std::int32_t sequence) {
     data_.timeMillisSequence = orOp(andOp(data_.timeMillisSequence, ~MAX_SEQUENCE), sequence);
 }
 
-Quote &Quote::withSequence(std::int32_t sequence) noexcept {
+Quote &Quote::withSequence(std::int32_t sequence) {
     setSequence(sequence);
 
     return *this;

--- a/src/event/market/SpreadOrder.cpp
+++ b/src/event/market/SpreadOrder.cpp
@@ -163,7 +163,7 @@ SpreadOrder &SpreadOrder::withTimeNanoPart(std::int32_t timeNanoPart) noexcept {
     return *this;
 }
 
-SpreadOrder &SpreadOrder::withSequence(std::int32_t sequence) noexcept {
+SpreadOrder &SpreadOrder::withSequence(std::int32_t sequence) {
     setSequence(sequence);
 
     return *this;

--- a/src/event/market/TimeAndSale.cpp
+++ b/src/event/market/TimeAndSale.cpp
@@ -211,7 +211,7 @@ void TimeAndSale::setSequence(std::int32_t sequence) {
         throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
     }
 
-    data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);
+    data_.index = orOp(andOp(data_.index, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
 std::int16_t TimeAndSale::getExchangeCode() const noexcept {

--- a/src/event/market/TradeBase.cpp
+++ b/src/event/market/TradeBase.cpp
@@ -120,7 +120,8 @@ void TradeBase::setSequence(std::int32_t sequence) {
         throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
     }
 
-    tradeBaseData_.timeSequence = orOp(andOp(tradeBaseData_.timeSequence, ~MAX_SEQUENCE), sequence);
+    tradeBaseData_.timeSequence =
+        orOp(andOp(tradeBaseData_.timeSequence, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
 std::int16_t TradeBase::getExchangeCode() const noexcept {

--- a/src/event/misc/Message.cpp
+++ b/src/event/misc/Message.cpp
@@ -22,6 +22,8 @@ void Message::fillData(void *graalNative) {
 
     auto graalMessage = static_cast<dxfg_message_t *>(graalNative);
 
+    setEventTime(graalMessage->event_time);
+
     if (graalMessage->event_symbol != nullptr) {
         setEventSymbol(dxfcpp::toString(graalMessage->event_symbol));
     }

--- a/src/event/misc/TextMessage.cpp
+++ b/src/event/misc/TextMessage.cpp
@@ -206,10 +206,10 @@ void TextMessage::setSequence(std::int32_t sequence) {
         throw InvalidArgumentException("Invalid sequence value = " + std::to_string(sequence));
     }
 
-    timeSequence_ = orOp(andOp(timeSequence_, ~MAX_SEQUENCE), sequence);
+    timeSequence_ = orOp(andOp(timeSequence_, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
-TextMessage &TextMessage::withSequence(std::int32_t sequence) noexcept {
+TextMessage &TextMessage::withSequence(std::int32_t sequence) {
     setSequence(sequence);
 
     return *this;

--- a/src/event/option/Greeks.cpp
+++ b/src/event/option/Greeks.cpp
@@ -170,7 +170,7 @@ void Greeks::setSequence(std::int32_t sequence) {
         throw InvalidArgumentException("Invalid value for argument `sequence`: " + std::to_string(sequence));
     }
 
-    data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);
+    data_.index = orOp(andOp(data_.index, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
 double Greeks::getPrice() const noexcept {

--- a/src/event/option/Series.cpp
+++ b/src/event/option/Series.cpp
@@ -87,10 +87,10 @@ void Series::setSequence(std::int32_t sequence) {
         throw InvalidArgumentException("Invalid value for argument `sequence`: " + std::to_string(sequence));
     }
 
-    data_.timeSequence = orOp(andOp(data_.timeSequence, ~MAX_SEQUENCE), sequence);
+    data_.timeSequence = orOp(andOp(data_.timeSequence, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
-Series &Series::withSequence(std::int32_t sequence) noexcept {
+Series &Series::withSequence(std::int32_t sequence) {
     setSequence(sequence);
 
     return *this;

--- a/src/event/option/TheoPrice.cpp
+++ b/src/event/option/TheoPrice.cpp
@@ -169,7 +169,7 @@ void TheoPrice::setSequence(std::int32_t sequence) {
         throw InvalidArgumentException("Invalid value for argument `sequence`: " + std::to_string(sequence));
     }
 
-    data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);
+    data_.index = orOp(andOp(data_.index, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
 double TheoPrice::getPrice() const noexcept {

--- a/src/event/option/Underlying.cpp
+++ b/src/event/option/Underlying.cpp
@@ -169,7 +169,7 @@ void Underlying::setSequence(std::int32_t sequence) {
         throw InvalidArgumentException("Invalid value for argument `sequence`: " + std::to_string(sequence));
     }
 
-    data_.index = orOp(andOp(data_.index, ~MAX_SEQUENCE), sequence);
+    data_.index = orOp(andOp(data_.index, ~static_cast<std::int64_t>(MAX_SEQUENCE)), sequence);
 }
 
 double Underlying::getVolatility() const noexcept {

--- a/src/internal/utils/StringUtils.cpp
+++ b/src/internal/utils/StringUtils.cpp
@@ -37,6 +37,43 @@ StringLike::StringLike(const std::string &s) : owned_(s), view_(owned_) {
 StringLike::StringLike(std::string &&s) noexcept : owned_(std::move(s)), view_(owned_) {
 }
 
+StringLike::StringLike(const StringLike &other) : owned_(other.owned_) {
+    view_ = other.view_.data() == other.owned_.data() ? std::string_view{owned_} : other.view_;
+}
+
+StringLike::StringLike(StringLike &&other) noexcept {
+    const auto ownsView = other.view_.data() == other.owned_.data();
+
+    owned_ = std::move(other.owned_);
+    view_ = ownsView ? std::string_view{owned_} : other.view_;
+}
+
+StringLike &StringLike::operator=(const StringLike &other) {
+    if (this == &other) {
+        return *this;
+    }
+
+    const auto ownsView = other.view_.data() == other.owned_.data();
+
+    owned_ = other.owned_;
+    view_ = ownsView ? std::string_view{owned_} : other.view_;
+
+    return *this;
+}
+
+StringLike &StringLike::operator=(StringLike &&other) noexcept {
+    if (this == &other) {
+        return *this;
+    }
+
+    const auto ownsView = other.view_.data() == other.owned_.data();
+
+    owned_ = std::move(other.owned_);
+    view_ = ownsView ? std::string_view{owned_} : other.view_;
+
+    return *this;
+}
+
 StringLike::operator std::string_view() const noexcept {
     return view_;
 }
@@ -186,10 +223,17 @@ std::string toString(double d) {
         return "NaN";
     }
 
-    auto x = fmt::format("{}", d);
-    auto y = fmt::format("{}", std::round(d));
+    if (std::isinf(d)) {
+        return std::signbit(d) ? "-Infinity" : "Infinity";
+    }
 
-    return x.size() == y.size() ? x + ".0" : x;
+    auto result = fmt::format("{}", d);
+
+    if (result.find_first_of(".eE") == std::string::npos) {
+        result += ".0";
+    }
+
+    return result;
 }
 
 std::string encodeChar(std::int16_t c) {

--- a/src/isolated/api/IsolatedDXEndpoint.cpp
+++ b/src/isolated/api/IsolatedDXEndpoint.cpp
@@ -59,7 +59,7 @@ void /* int32_t */ user(/* dxfg_endpoint_t* */ const JavaObjectHandle<DXEndpoint
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_DXEndpoint_user, static_cast<dxfg_endpoint_t *>(endpoint.get()),
-                                           user.data());
+                                           user.c_str());
 }
 
 void /* int32_t */ password(/* dxfg_endpoint_t* */ const JavaObjectHandle<DXEndpoint> &endpoint,
@@ -70,7 +70,7 @@ void /* int32_t */ password(/* dxfg_endpoint_t* */ const JavaObjectHandle<DXEndp
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_DXEndpoint_password, static_cast<dxfg_endpoint_t *>(endpoint.get()),
-                                           password.data());
+                                           password.c_str());
 }
 
 void connect(/* dxfg_endpoint_t* */ const JavaObjectHandle<DXEndpoint> &endpoint, const StringLike& address) {
@@ -80,7 +80,7 @@ void connect(/* dxfg_endpoint_t* */ const JavaObjectHandle<DXEndpoint> &endpoint
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_DXEndpoint_connect, static_cast<dxfg_endpoint_t *>(endpoint.get()),
-                                           address.data());
+                                           address.c_str());
 }
 
 void reconnect(/* dxfg_endpoint_t* */ const JavaObjectHandle<DXEndpoint> &endpoint) {
@@ -273,8 +273,8 @@ withProperty(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<DXEndpoint::
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_DXEndpoint_Builder_withProperty,
-                                           static_cast<dxfg_endpoint_builder_t *>(builder.get()), key.data(),
-                                           value.data());
+                                           static_cast<dxfg_endpoint_builder_t *>(builder.get()), key.c_str(),
+                                           value.c_str());
 }
 
 // dxfg_DXEndpoint_Builder_withProperties
@@ -287,7 +287,7 @@ withProperties(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<DXEndpoint
     }
 
     runGraalFunctionAndThrowIfLessThanZero(dxfg_DXEndpoint_Builder_withProperties,
-                                           static_cast<dxfg_endpoint_builder_t *>(builder.get()), filePath.data());
+                                           static_cast<dxfg_endpoint_builder_t *>(builder.get()), filePath.c_str());
 }
 
 // dxfg_DXEndpoint_Builder_supportsProperty
@@ -301,7 +301,7 @@ supportsProperty(/* dxfg_endpoint_builder_t * */ const JavaObjectHandle<DXEndpoi
 
     return runGraalFunctionAndThrowIfLessThanZero(dxfg_DXEndpoint_Builder_supportsProperty,
                                                   static_cast<dxfg_endpoint_builder_t *>(builder.get()),
-                                                  key.data()) == 1;
+                                                  key.c_str()) == 1;
 }
 
 // dxfg_DXEndpoint_Builder_build

--- a/src/isolated/auth/IsolatedAuthToken.cpp
+++ b/src/isolated/auth/IsolatedAuthToken.cpp
@@ -16,21 +16,21 @@ namespace isolated::auth::IsolatedAuthToken {
 
 /// dxfg_AuthToken_valueOf
 /* dxfg_auth_token_t* */ JavaObjectHandle<AuthToken> valueOf(/* const char* */ const StringLike &string) {
-    return JavaObjectHandle<AuthToken>(runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_valueOf, string.data()));
+    return JavaObjectHandle<AuthToken>(runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_valueOf, string.c_str()));
 }
 
 /// dxfg_AuthToken_createBasicToken
 /* dxfg_auth_token_t* */ JavaObjectHandle<AuthToken>
 createBasicToken(/* const char* */ const StringLike &userPassword) {
     return JavaObjectHandle<AuthToken>(
-        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBasicToken, userPassword.data()));
+        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBasicToken, userPassword.c_str()));
 }
 
 /// dxfg_AuthToken_createBasicToken2
 /* dxfg_auth_token_t* */ JavaObjectHandle<AuthToken> createBasicToken(/* const char* */ const StringLike &user,
                                                                       /* const char* */ const StringLike &password) {
     return JavaObjectHandle<AuthToken>(
-        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBasicToken2, user.data(), password.data()));
+        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBasicToken2, user.c_str(), password.c_str()));
 }
 
 /// dxfg_AuthToken_createBasicTokenOrNull
@@ -38,27 +38,27 @@ createBasicToken(/* const char* */ const StringLike &userPassword) {
 createBasicTokenOrNull(/* const char* */ const StringLike &user,
                        /* const char* */ const StringLike &password) {
     return JavaObjectHandle<AuthToken>(
-        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBasicTokenOrNull, user.data(), password.data()));
+        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBasicTokenOrNull, user.c_str(), password.c_str()));
 }
 
 /// dxfg_AuthToken_createBearerToken
 /* dxfg_auth_token_t* */ JavaObjectHandle<AuthToken> createBearerToken(/* const char* */ const StringLike &token) {
     return JavaObjectHandle<AuthToken>(
-        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBearerToken, token.data()));
+        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBearerToken, token.c_str()));
 }
 
 /// dxfg_AuthToken_createBearerTokenOrNull
 /* dxfg_auth_token_t* */ JavaObjectHandle<AuthToken>
 createBearerTokenOrNull(/* const char* */ const StringLike &token) {
     return JavaObjectHandle<AuthToken>(
-        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBearerTokenOrNull, token.data()));
+        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createBearerTokenOrNull, token.c_str()));
 }
 
 /// dxfg_AuthToken_createCustomToken
 /* dxfg_auth_token_t* */ JavaObjectHandle<AuthToken> createCustomToken(/* const char* */ const StringLike &scheme,
                                                                        /* const char* */ const StringLike &value) {
     return JavaObjectHandle<AuthToken>(
-        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createCustomToken, scheme.data(), value.data()));
+        runGraalFunctionAndThrowIfNullptr(dxfg_AuthToken_createCustomToken, scheme.c_str(), value.c_str()));
 }
 
 /// dxfg_AuthToken_getHttpAuthorization

--- a/src/isolated/internal/IsolatedTimeFormat.cpp
+++ b/src/isolated/internal/IsolatedTimeFormat.cpp
@@ -53,7 +53,7 @@ std::int64_t parse(/* dxfg_time_format_t* */ const JavaObjectHandle<TimeFormat> 
     }
 
     return runGraalFunctionAndThrowIfMinusOne(dxfg_TimeFormat_parse,
-                                              static_cast<dxfg_time_format_t *>(timeFormat.get()), value.data());
+                                              static_cast<dxfg_time_format_t *>(timeFormat.get()), value.c_str());
 }
 
 std::string format(/* dxfg_time_format_t* */ const JavaObjectHandle<TimeFormat> &timeFormat,

--- a/src/isolated/internal/IsolatedTools.cpp
+++ b/src/isolated/internal/IsolatedTools.cpp
@@ -19,7 +19,7 @@ std::unordered_set<std::string> /* dxfg_string_list* */
 parseSymbols(const StringLike& symbolList) {
     std::unordered_set<std::string> result{};
 
-    auto graalStringList = runGraalFunctionAndThrowIfNullptr(dxfg_Tools_parseSymbols, symbolList.data());
+    auto graalStringList = runGraalFunctionAndThrowIfNullptr(dxfg_Tools_parseSymbols, symbolList.c_str());
 
     for (auto i = 0; i < graalStringList->size; i++) {
         result.emplace(dxfcpp::toString(graalStringList->elements[i]));
@@ -33,7 +33,7 @@ parseSymbols(const StringLike& symbolList) {
 std::vector<std::string> /* dxfg_string_list* */ parseSymbolsAndSaveOrder(const StringLike& symbolList) {
     std::vector<std::string> result{};
 
-    auto graalStringList = runGraalFunctionAndThrowIfNullptr(dxfg_Tools_parseSymbols, symbolList.data());
+    auto graalStringList = runGraalFunctionAndThrowIfNullptr(dxfg_Tools_parseSymbols, symbolList.c_str());
 
     result.reserve(graalStringList->size);
 

--- a/src/isolated/util/IsolatedTimePeriod.cpp
+++ b/src/isolated/util/IsolatedTimePeriod.cpp
@@ -24,7 +24,7 @@ namespace isolated::util::IsolatedTimePeriod {
 }
 
 /* dxfg_time_period_t* */ JavaObjectHandle<TimePeriod> valueOf(const StringLike& value) {
-    return JavaObjectHandle<TimePeriod>(runGraalFunctionAndThrowIfNullptr(dxfg_TimePeriod_valueOf2, value.data()));
+    return JavaObjectHandle<TimePeriod>(runGraalFunctionAndThrowIfNullptr(dxfg_TimePeriod_valueOf2, value.c_str()));
 }
 
 std::int64_t getTime(/* dxfg_time_period_t* */ const JavaObjectHandle<TimePeriod> &timePeriod) {

--- a/tests/api/CandleSymbolTest.cpp
+++ b/tests/api/CandleSymbolTest.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include <fmt/format.h>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -97,4 +98,35 @@ TEST_CASE("Double checks") {
             CandleSymbol::valueOf(
                 "AAPL", std::vector<CandleSymbolAttributeVariant>{CandlePeriod::valueOf(15, CandleType::MINUTE)})
                 .toString());
+}
+
+TEST_CASE("CandlePeriod string representation should round-trip small values") {
+    const auto period = CandlePeriod::valueOf(1.0e-8, CandleType::PRICE);
+
+    CHECK(CandlePeriod::parse(period.toString()) == period);
+    CHECK(period.getValue() == 1.0e-8);
+}
+
+TEST_CASE("CandlePriceLevel should follow Java validation and equality semantics") {
+    CHECK(CandlePriceLevel::DEFAULT == CandlePriceLevel::DEFAULT);
+    CHECK(CandlePriceLevel::valueOf(std::numeric_limits<double>::quiet_NaN()) == CandlePriceLevel::DEFAULT);
+    CHECK(CandlePriceLevel::DEFAULT.changeAttributeForSymbol("AAPL{pl=1}") == "AAPL");
+    CHECK(CandlePriceLevel::valueOf(1.0).toString() == "1");
+    CHECK(CandlePriceLevel::valueOf(0.0) != CandlePriceLevel::valueOf(1.0e-20));
+
+    CHECK_THROWS_AS(CandlePriceLevel::valueOf(-1.0), InvalidArgumentException);
+    CHECK_THROWS_AS(CandlePriceLevel::valueOf(-0.0), InvalidArgumentException);
+    CHECK_THROWS_AS(CandlePriceLevel::valueOf(std::numeric_limits<double>::infinity()), InvalidArgumentException);
+    CHECK_THROWS_AS(CandlePriceLevel::parse("1garbage"), InvalidArgumentException);
+}
+
+TEST_CASE("CandleSession attribute lookup should use Boolean.parseBoolean semantics") {
+    CHECK(CandleSession::getAttributeForSymbol("AAPL{tho=true}").get() == CandleSession::REGULAR);
+    CHECK(CandleSession::getAttributeForSymbol("AAPL{tho=TRUE}").get() == CandleSession::REGULAR);
+    CHECK(CandleSession::getAttributeForSymbol("AAPL{tho=t}").get() == CandleSession::DEFAULT);
+    CHECK(CandleSession::getAttributeForSymbol("AAPL{tho=garbage}").get() == CandleSession::DEFAULT);
+}
+
+TEST_CASE("CandleSymbol should report invalid attributes as exceptions") {
+    CHECK_THROWS_AS(CandleSymbol::valueOf("AAPL{=garbage}"), InvalidArgumentException);
 }

--- a/tests/api/EventsTest.cpp
+++ b/tests/api/EventsTest.cpp
@@ -46,14 +46,18 @@ TEST_CASE("Candle::setTime() should change Index") {
 
 TEST_CASE("Candle::setSequence() should change Index") {
     auto c = Candle("AAPL"_c);
+    c.setTime(1'701'703'226'537LL);
     auto oldIndex = c.getIndex();
+    auto oldTime = c.getTime();
     std::int32_t sequence = 567;
 
     c.setSequence(sequence);
 
-    auto expectedIndex = dxfcpp::orOp(dxfcpp::andOp(oldIndex, ~CandleConstants::MAX_SEQUENCE), sequence);
+    auto expectedIndex = dxfcpp::orOp(
+        dxfcpp::andOp(oldIndex, ~static_cast<std::int64_t>(CandleConstants::MAX_SEQUENCE)), sequence);
 
     REQUIRE(c.getIndex() == expectedIndex);
+    REQUIRE(c.getTime() == oldTime);
 }
 
 struct OptionSaleConstants {
@@ -211,14 +215,18 @@ TEST_CASE("TimeAndSale::setTime() should change Index") {
 
 TEST_CASE("TimeAndSale::setSequence() should change Index") {
     auto tns = TimeAndSale("AAPL");
+    tns.setTime(1'701'703'226'556LL);
     auto oldIndex = tns.getIndex();
+    auto oldTime = tns.getTime();
     std::int32_t sequence = 567;
 
     tns.setSequence(sequence);
 
-    auto expectedIndex = dxfcpp::orOp(dxfcpp::andOp(oldIndex, ~TimeAndSaleConstants::MAX_SEQUENCE), sequence);
+    auto expectedIndex = dxfcpp::orOp(
+        dxfcpp::andOp(oldIndex, ~static_cast<std::int64_t>(TimeAndSaleConstants::MAX_SEQUENCE)), sequence);
 
     REQUIRE(tns.getIndex() == expectedIndex);
+    REQUIRE(tns.getTime() == oldTime);
 }
 
 struct TradeConstants {
@@ -297,14 +305,18 @@ TEST_CASE("Greeks::setTime() should change Index") {
 
 TEST_CASE("Greeks::setSequence() should change Index") {
     auto g = Greeks("AAPL");
+    g.setTime(1'701'703'226'535LL);
     auto oldIndex = g.getIndex();
+    auto oldTime = g.getTime();
     std::int32_t sequence = 567;
 
     g.setSequence(sequence);
 
-    auto expectedIndex = dxfcpp::orOp(dxfcpp::andOp(oldIndex, ~GreeksConstants::MAX_SEQUENCE), sequence);
+    auto expectedIndex = dxfcpp::orOp(
+        dxfcpp::andOp(oldIndex, ~static_cast<std::int64_t>(GreeksConstants::MAX_SEQUENCE)), sequence);
 
     REQUIRE(g.getIndex() == expectedIndex);
+    REQUIRE(g.getTime() == oldTime);
 }
 
 struct SeriesConstants {
@@ -396,14 +408,18 @@ TEST_CASE("TheoPrice::setTime() should change Index") {
 
 TEST_CASE("TheoPrice::setSequence() should change Index") {
     auto tp = TheoPrice("AAPL");
+    tp.setTime(1'701'703'226'535LL);
     auto oldIndex = tp.getIndex();
+    auto oldTime = tp.getTime();
     std::int32_t sequence = 567;
 
     tp.setSequence(sequence);
 
-    auto expectedIndex = dxfcpp::orOp(dxfcpp::andOp(oldIndex, ~TheoPriceConstants::MAX_SEQUENCE), sequence);
+    auto expectedIndex = dxfcpp::orOp(
+        dxfcpp::andOp(oldIndex, ~static_cast<std::int64_t>(TheoPriceConstants::MAX_SEQUENCE)), sequence);
 
     REQUIRE(tp.getIndex() == expectedIndex);
+    REQUIRE(tp.getTime() == oldTime);
 }
 
 struct UnderlyingConstants {
@@ -437,12 +453,59 @@ TEST_CASE("Underlying::setTime() should change Index") {
 
 TEST_CASE("Underlying::setSequence() should change Index") {
     auto u = Underlying("AAPL");
+    u.setTime(1'701'703'226'535LL);
     auto oldIndex = u.getIndex();
+    auto oldTime = u.getTime();
     std::int32_t sequence = 567;
 
     u.setSequence(sequence);
 
-    auto expectedIndex = dxfcpp::orOp(dxfcpp::andOp(oldIndex, ~UnderlyingConstants::MAX_SEQUENCE), sequence);
+    auto expectedIndex = dxfcpp::orOp(
+        dxfcpp::andOp(oldIndex, ~static_cast<std::int64_t>(UnderlyingConstants::MAX_SEQUENCE)), sequence);
 
     REQUIRE(u.getIndex() == expectedIndex);
+    REQUIRE(u.getTime() == oldTime);
+}
+
+TEST_CASE("setSequence() should preserve time in every event with a 64-bit packed field") {
+    constexpr std::int64_t time = 1'701'703'226'537LL;
+    constexpr std::int32_t sequence = 567;
+
+    const auto check = [time, sequence](auto event) {
+        event.setTime(time);
+        event.setSequence(sequence);
+
+        CHECK(event.getTime() == time);
+        CHECK(event.getSequence() == sequence);
+    };
+
+    check(Candle("AAPL"_c));
+    check(OptionSale("AAPL"));
+    check(Order("AAPL"));
+    check(TimeAndSale("AAPL"));
+    check(Trade("AAPL"));
+    check(TextMessage("AAPL"));
+    check(Greeks("AAPL"));
+    check(Series("AAPL"));
+    check(TheoPrice("AAPL"));
+    check(Underlying("AAPL"));
+}
+
+TEST_CASE("withSequence() should propagate validation errors") {
+    CHECK_THROWS_AS(Candle("AAPL"_c).withSequence(-1), InvalidArgumentException);
+    CHECK_THROWS_AS(Order("AAPL").withSequence(-1), InvalidArgumentException);
+    CHECK_THROWS_AS(Quote("AAPL").withSequence(-1), InvalidArgumentException);
+}
+
+TEST_CASE("Message Graal conversion should preserve event time") {
+    auto original = Message("notifications", "payload");
+    original.setEventTime(1'701'703'226'537LL);
+    auto graalMessage = original.toGraal();
+    auto restored = Message::fromGraal(graalMessage);
+
+    CHECK(restored->getEventTime() == original.getEventTime());
+    CHECK(restored->getEventSymbol() == original.getEventSymbol());
+    CHECK(restored->getAttachment() == original.getAttachment());
+
+    Message::freeGraal(graalMessage);
 }

--- a/tests/api/OrderSourceTest.cpp
+++ b/tests/api/OrderSourceTest.cpp
@@ -20,3 +20,14 @@ TEST_CASE("OrderSource::valueOf the method should work correctly with predefined
     REQUIRE(OrderSource::valueOf("NTV") != OrderSource::ntv);
     REQUIRE(OrderSource::valueOf("NTV2") != OrderSource::NTV);
 }
+
+TEST_CASE("OrderBase::setSource should preserve the low index bits") {
+    constexpr std::int64_t index = 123'456'789LL;
+    auto order = Order("AAPL");
+
+    order.setIndex(index);
+    order.setSource(OrderSource::NTV);
+
+    CHECK(order.getSource() == OrderSource::NTV);
+    CHECK((order.getIndex() & 0xffff'ffffLL) == index);
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -102,10 +102,11 @@ void setSignalHandler() {
 }
 #endif
 
-int main(int /*argc*/, char ** /*argv*/) {
+int main(int argc, char **argv) {
     setSignalHandler();
 
     doctest::Context context;
+    context.applyCommandLine(argc, argv);
 
     const int res = context.run(); // run queries, or run tests unless --no-run is specified
 

--- a/tests/symbols/SymbolWrapperTest.cpp
+++ b/tests/symbols/SymbolWrapperTest.cpp
@@ -23,3 +23,21 @@ TEST_CASE("SymbolWrapper::toStringUnderlying should return the result of toStrin
     REQUIRE(SymbolWrapper(c).toString() != c.toString());
     REQUIRE(SymbolWrapper(WildcardSymbol::ALL).toString() != WildcardSymbol::ALL.toString());
 }
+
+TEST_CASE("StringLike should preserve owned data when copied and moved") {
+    auto original = StringLike(std::string{"short value"});
+    auto copy = original;
+    auto moved = std::move(copy);
+
+    original = StringLike(std::string{"a different and longer value"});
+
+    CHECK(std::string{moved} == "short value");
+    CHECK(std::string{moved.c_str()} == "short value");
+}
+
+TEST_CASE("StringLike::c_str should terminate a sliced string view at its boundary") {
+    const auto storage = std::string{"visible-hidden"};
+    const auto slice = StringLike(std::string_view{storage}.substr(0, 7));
+
+    CHECK(std::string{slice.c_str()} == "visible");
+}


### PR DESCRIPTION
  * `setSequence()` and `OrderBase::setSource()` now preserve unrelated packed bits; `Message` native conversion
    preserves event time; `StringLike` copy/move operations and native C-string handling are now safe.
  * Candle equality, formatting, price-level validation/parsing, and session parsing now match Java QD semantics.
    Price levels reject negative values, negative zero, infinities, and trailing parse data; floating-point equality
    follows Java NaN/signed-zero rules; only case-insensitive `"true"` enables the regular candle session.
  * APIs that can fail validation or parsing are no longer `noexcept`; invalid input now throws an exception instead
    of terminating the process.